### PR TITLE
Use http transport for public client

### DIFF
--- a/packages/agw-sdk/src/abstractClient.ts
+++ b/packages/agw-sdk/src/abstractClient.ts
@@ -57,7 +57,7 @@ export async function createAbstractClient({
 
   const publicClient = createPublicClient({
     chain: chain,
-    transport,
+    transport: http(),
   });
 
   const smartAccountAddress = await getSmartAccountAddressFromInitialSigner(


### PR DESCRIPTION
The public client should always use the default http transport. I ran into this issue when I was experimenting and trying to pass in an EOA transport the other day. The `zks` rpc methods will fail since most wallets won't recognize those.