### PR TITLE
Remove validatorAddres argument

### DIFF
--- a/packages/agw-client/src/actions/deployContract.ts
+++ b/packages/agw-client/src/actions/deployContract.ts
@@ -3,7 +3,6 @@ import {
   type Account,
   type Client,
   type ContractConstructorArgs,
-  type Hex,
   type PublicClient,
   type Transport,
   type WalletClient,
@@ -36,7 +35,6 @@ export function deployContract<
     chainOverride,
     allArgs
   >,
-  validatorAddress: Hex,
 ): Promise<DeployContractReturnType> {
   const { abi, args, bytecode, deploymentType, salt, ...request } =
     parameters as DeployContractParameters;
@@ -54,19 +52,13 @@ export function deployContract<
   if (!request.factoryDeps.includes(bytecode))
     request.factoryDeps.push(bytecode);
 
-  return sendTransaction(
-    walletClient,
-    signerClient,
-    publicClient,
-    {
-      ...request,
-      data,
-      to: CONTRACT_DEPLOYER_ADDRESS,
-    } as unknown as SendEip712TransactionParameters<
-      chain,
-      account,
-      chainOverride
-    >,
-    validatorAddress,
-  );
+  return sendTransaction(walletClient, signerClient, publicClient, {
+    ...request,
+    data,
+    to: CONTRACT_DEPLOYER_ADDRESS,
+  } as unknown as SendEip712TransactionParameters<
+    chain,
+    account,
+    chainOverride
+  >);
 }

--- a/packages/agw-client/src/actions/sendTransaction.ts
+++ b/packages/agw-client/src/actions/sendTransaction.ts
@@ -23,6 +23,7 @@ import AccountFactoryAbi from '../abis/AccountFactory.js';
 import {
   BATCH_CALLER_ADDRESS,
   SMART_ACCOUNT_FACTORY_ADDRESS,
+  VALIDATOR_ADDRESS,
 } from '../constants.js';
 import { type Call } from '../types/call.js';
 import { getInitializerCalldata, isSmartAccountDeployed } from '../utils.js';
@@ -48,7 +49,6 @@ export async function sendTransactionBatch<
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
   publicClient: PublicClient<Transport, ChainEIP712>,
   parameters: SendTransactionBatchParameters<request>,
-  validatorAddress: Hex,
 ): Promise<SendTransactionReturnType> {
   if (parameters.calls.length === 0) {
     throw new Error('No calls provided');
@@ -110,7 +110,7 @@ export async function sendTransactionBatch<
     // Create calldata for initializing the proxy account
     const initializerCallData = getInitializerCalldata(
       signerClient.account.address,
-      validatorAddress,
+      VALIDATOR_ADDRESS,
       initialCall,
     );
     const addressBytes = toBytes(signerClient.account.address);
@@ -145,7 +145,6 @@ export async function sendTransactionBatch<
     signerClient,
     publicClient,
     batchTransaction,
-    validatorAddress,
     !isDeployed,
   );
 }
@@ -168,7 +167,6 @@ export async function sendTransaction<
     chainOverride,
     request
   >,
-  validatorAddress: Hex,
 ): Promise<SendEip712TransactionReturnType> {
   const isDeployed = await isSmartAccountDeployed(
     publicClient,
@@ -185,7 +183,7 @@ export async function sendTransaction<
     // Create calldata for initializing the proxy account
     const initializerCallData = getInitializerCalldata(
       signerClient.account.address,
-      validatorAddress,
+      VALIDATOR_ADDRESS,
       initialCall,
     );
     const addressBytes = toBytes(signerClient.account.address);
@@ -207,7 +205,6 @@ export async function sendTransaction<
     signerClient,
     publicClient,
     parameters,
-    validatorAddress,
     !isDeployed,
   );
 }

--- a/packages/agw-client/src/actions/sendTransactionInternal.ts
+++ b/packages/agw-client/src/actions/sendTransactionInternal.ts
@@ -2,7 +2,6 @@ import {
   type Account,
   type Chain,
   type Client,
-  type Hex,
   type PublicClient,
   type SendTransactionRequest,
   type Transport,
@@ -44,7 +43,6 @@ export async function sendTransactionInternal<
     chainOverride,
     request
   >,
-  validatorAddress: Hex,
   isInitialTransaction: boolean,
 ): Promise<SendEip712TransactionReturnType> {
   const { chain = client.chain } = parameters;
@@ -86,7 +84,6 @@ export async function sendTransactionInternal<
         ...request,
         chainId,
       } as any,
-      validatorAddress,
       isInitialTransaction,
     );
 

--- a/packages/agw-client/src/actions/signTransaction.ts
+++ b/packages/agw-client/src/actions/signTransaction.ts
@@ -3,7 +3,6 @@ import {
   BaseError,
   type Client,
   encodeAbiParameters,
-  type Hex,
   parseAbiParameters,
   type Transport,
   type WalletClient,
@@ -17,6 +16,7 @@ import {
   type SignEip712TransactionReturnType,
 } from 'viem/zksync';
 
+import { VALIDATOR_ADDRESS } from '../constants.js';
 import {
   assertEip712Request,
   type AssertEip712RequestParameters,
@@ -33,7 +33,6 @@ export async function signTransaction<
   client: Client<Transport, ChainEIP712, Account>,
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
   args: SignEip712TransactionParameters<chain, account, chainOverride>,
-  validatorAddress: Hex,
   useSignerAddress = false,
 ): Promise<SignEip712TransactionReturnType> {
   const {
@@ -95,7 +94,7 @@ export async function signTransaction<
     // Match the expect signature format of the AGW smart account
     signature = encodeAbiParameters(
       parseAbiParameters(['bytes', 'address', 'bytes[]']),
-      [rawSignature, validatorAddress, []],
+      [rawSignature, VALIDATOR_ADDRESS, []],
     );
   }
 

--- a/packages/agw-client/src/actions/writeContract.ts
+++ b/packages/agw-client/src/actions/writeContract.ts
@@ -7,7 +7,6 @@ import {
   type ContractFunctionName,
   encodeFunctionData,
   type EncodeFunctionDataParameters,
-  type Hex,
   type PublicClient,
   type Transport,
   type WalletClient,
@@ -43,7 +42,6 @@ export async function writeContract<
     account,
     chainOverride
   >,
-  validatorAddress: Hex,
 ): Promise<WriteContractReturnType> {
   const {
     abi,
@@ -68,18 +66,12 @@ export async function writeContract<
   } as EncodeFunctionDataParameters);
 
   try {
-    return await sendTransaction(
-      client,
-      signerClient,
-      publicClient,
-      {
-        data: `${data}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
-        to: address,
-        account,
-        ...request,
-      },
-      validatorAddress,
-    );
+    return await sendTransaction(client, signerClient, publicClient, {
+      data: `${data}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
+      to: address,
+      account,
+      ...request,
+    });
   } catch (error) {
     throw getContractError(error as BaseError, {
       abi,

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -25,7 +25,6 @@ import {
 } from './actions/sendTransaction.js';
 import { signTransaction } from './actions/signTransaction.js';
 import { writeContract } from './actions/writeContract.js';
-import { VALIDATOR_ADDRESS } from './constants.js';
 
 export type AbstractWalletActions<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
@@ -45,7 +44,6 @@ export function globalWalletActions<
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
   publicClient: PublicClient<Transport, ChainEIP712>,
 ) {
-  const validatorAddress = VALIDATOR_ADDRESS;
   return (
     client: Client<Transport, ChainEIP712, Account>,
   ): AbstractWalletActions<Chain, Account> => ({
@@ -55,44 +53,23 @@ export function globalWalletActions<
         signerClient,
         publicClient,
         args as SendEip712TransactionParameters<chain, account>,
-        validatorAddress,
       ),
     sendTransactionBatch: (args) =>
-      sendTransactionBatch(
-        client,
-        signerClient,
-        publicClient,
-        args,
-        validatorAddress,
-      ),
+      sendTransactionBatch(client, signerClient, publicClient, args),
     signTransaction: (args) =>
       signTransaction(
         client,
         signerClient,
         args as SignEip712TransactionParameters<chain, account>,
-        validatorAddress,
       ),
     deployContract: (args) =>
-      deployContract(
-        client,
-        signerClient,
-        publicClient,
-        args,
-        validatorAddress,
-      ),
+      deployContract(client, signerClient, publicClient, args),
     writeContract: (args) =>
       writeContract(
         Object.assign(client, {
           sendTransaction: (
             args: SendEip712TransactionParameters<chain, account>,
-          ) =>
-            sendTransaction(
-              client,
-              signerClient,
-              publicClient,
-              args,
-              validatorAddress,
-            ),
+          ) => sendTransaction(client, signerClient, publicClient, args),
         }),
         signerClient,
         publicClient,
@@ -103,7 +80,6 @@ export function globalWalletActions<
           ChainEIP712,
           Account
         >,
-        validatorAddress,
       ),
   });
 }

--- a/packages/agw-client/test/src/actions/deployContract.test.ts
+++ b/packages/agw-client/test/src/actions/deployContract.test.ts
@@ -82,7 +82,6 @@ test('create2 with factoryDeps', async () => {
       deploymentType: 'create2',
       salt: MOCK_SALT,
     },
-    address.validatorAddress,
   );
 
   expect(transactionHash).toBe('0xmockedTransactionHash');
@@ -98,7 +97,6 @@ test('create2 with factoryDeps', async () => {
       factoryDeps: [contractBytecode],
       to: CONTRACT_DEPLOYER_ADDRESS,
     },
-    address.validatorAddress,
   );
 });
 
@@ -124,7 +122,6 @@ test('create2 with no chain and no account', async () => {
       deploymentType: 'create2',
       salt: MOCK_SALT,
     },
-    address.validatorAddress,
   );
 
   expect(transactionHash).toBe('0xmockedTransactionHash');
@@ -140,6 +137,5 @@ test('create2 with no chain and no account', async () => {
       factoryDeps: [contractBytecode],
       to: CONTRACT_DEPLOYER_ADDRESS,
     },
-    address.validatorAddress,
   );
 });

--- a/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   BATCH_CALLER_ADDRESS,
   SMART_ACCOUNT_FACTORY_ADDRESS,
+  VALIDATOR_ADDRESS,
 } from '../../../../src/constants.js';
 import {
   getInitializerCalldata,
@@ -123,7 +124,6 @@ describe('sendTransaction', () => {
           account: baseClient.account,
           chain: anvilAbstractTestnet.chain as ChainEIP712,
         } as any,
-        address.validatorAddress,
       );
 
       if (shouldCallEncodeFunctionData) {
@@ -150,7 +150,6 @@ describe('sendTransaction', () => {
           account: baseClient.account,
           chain: anvilAbstractTestnet.chain as ChainEIP712,
         }),
-        address.validatorAddress,
         !isDeployed,
       );
       expect(transactionHash).toBe('0xmockedTransactionHash');
@@ -243,7 +242,6 @@ describe('sendTransactionBatch', () => {
           paymaster: '0x5407B5040dec3D339A9247f3654E59EEccbb6391',
           paymasterInput: '0xabc',
         } as any,
-        address.validatorAddress,
       );
 
       expect(encodeFunctionData).toHaveBeenCalledTimes(
@@ -262,7 +260,7 @@ describe('sendTransactionBatch', () => {
         // Verify that getInitializerCalldata is called with the correct arguments
         expect(getInitializerCalldata).toHaveBeenCalledWith(
           address.signerAddress,
-          address.validatorAddress,
+          VALIDATOR_ADDRESS,
           {
             target: BATCH_CALLER_ADDRESS,
             allowFailure: false,
@@ -300,7 +298,6 @@ describe('sendTransactionBatch', () => {
           paymasterInput: '0xabc',
           value: BigInt(1000),
         }),
-        address.validatorAddress,
         !isDeployed,
       );
       expect(transactionHash).toBe('0xmockedTransactionHash');

--- a/packages/agw-client/test/src/actions/sendTransaction/sendTransactionInternal.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransaction/sendTransactionInternal.test.ts
@@ -113,7 +113,6 @@ describe('sendTransactionInternal', () => {
           account: baseClient.account,
           chain: anvilAbstractTestnet.chain as ChainEIP712,
         } as any,
-        address.validatorAddress,
         isInitialTransaction,
       );
 
@@ -132,7 +131,6 @@ describe('sendTransactionInternal', () => {
           paymasterInput: '0x',
           chainId: abstractTestnet.id,
         }),
-        address.validatorAddress,
         isInitialTransaction,
       );
 
@@ -163,7 +161,6 @@ test('sendTransactionInternal with mismatched chain', async () => {
           account: baseClient.account,
           chain: invalidChain,
         } as any,
-        address.validatorAddress,
         false,
       ),
   ).rejects.toThrowError('Current Chain ID:  11124');

--- a/packages/agw-client/test/src/actions/signTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/signTransaction.test.ts
@@ -17,6 +17,7 @@ import {
 import { expect, test } from 'vitest';
 
 import { signTransaction } from '../../../src/actions/signTransaction.js';
+import { VALIDATOR_ADDRESS } from '../../../src/constants.js';
 import { anvilAbstractTestnet } from '../anvil.js';
 import { address } from '../constants.js';
 
@@ -58,7 +59,7 @@ const transaction: ZksyncTransactionRequestEIP712 = {
 test('with useSignerAddress false', async () => {
   const signature = encodeAbiParameters(
     parseAbiParameters(['bytes', 'address', 'bytes[]']),
-    [RAW_SIGNATURE, address.validatorAddress, []],
+    [RAW_SIGNATURE, VALIDATOR_ADDRESS, []],
   );
 
   const expectedSignedTransaction =
@@ -82,7 +83,6 @@ test('with useSignerAddress false', async () => {
       account: baseClient.account,
       chain: anvilAbstractTestnet.chain as ChainEIP712,
     } as SignEip712TransactionParameters,
-    address.validatorAddress,
     false,
   );
   expect(signedTransaction).toBe(expectedSignedTransaction);
@@ -112,7 +112,6 @@ test('with useSignerAddress true', async () => {
       account: baseClient.account,
       chain: anvilAbstractTestnet.chain as ChainEIP712,
     } as SignEip712TransactionParameters,
-    address.validatorAddress,
     true,
   );
   expect(signedTransaction).toBe(expectedSignedTransaction);
@@ -131,7 +130,6 @@ test('invalid chain', async () => {
           account: baseClient.account,
           chain: invalidChain,
         } as SignEip712TransactionParameters,
-        address.validatorAddress,
         true,
       ),
   ).rejects.toThrowError('Invalid chain specified');
@@ -149,7 +147,6 @@ test('no account provided', async () => {
           type: 'eip712',
           chain: anvilAbstractTestnet.chain as ChainEIP712,
         } as any,
-        address.validatorAddress,
         false,
       ),
   ).rejects.toThrowError(

--- a/packages/agw-client/test/src/actions/writeContract.test.ts
+++ b/packages/agw-client/test/src/actions/writeContract.test.ts
@@ -96,7 +96,6 @@ test('basic', async () => {
       functionName: 'mint',
       args: [address.signerAddress, 1n],
     },
-    address.validatorAddress,
   );
 
   expect(transactionHash).toBe('0xmockedTransactionHash');
@@ -111,7 +110,6 @@ test('basic', async () => {
       data: expectedData,
       to: MOCK_CONTRACT_ADDRESS,
     },
-    address.validatorAddress,
   );
 });
 
@@ -127,20 +125,14 @@ test('getContractError', async () => {
   });
 
   await expect(
-    writeContract(
-      baseClient,
-      signerClient,
-      publicClient,
-      {
-        abi: TestTokenABI,
-        account: baseClient.account,
-        address: MOCK_CONTRACT_ADDRESS,
-        chain: anvilAbstractTestnet.chain as ChainEIP712,
-        functionName: 'mint',
-        args: [address.signerAddress, 1n],
-      },
-      address.validatorAddress,
-    ),
+    writeContract(baseClient, signerClient, publicClient, {
+      abi: TestTokenABI,
+      account: baseClient.account,
+      address: MOCK_CONTRACT_ADDRESS,
+      chain: anvilAbstractTestnet.chain as ChainEIP712,
+      functionName: 'mint',
+      args: [address.signerAddress, 1n],
+    }),
   ).rejects.toThrowError('Mocked getContractError');
 
   expect(sendTransaction).toHaveBeenCalledWith(
@@ -153,7 +145,6 @@ test('getContractError', async () => {
       data: expectedData,
       to: MOCK_CONTRACT_ADDRESS,
     },
-    address.validatorAddress,
   );
 
   expect(getContractError).toHaveBeenCalledWith(
@@ -174,20 +165,14 @@ test('account not found', async () => {
   (baseClient as any).account = undefined;
 
   await expect(
-    writeContract(
-      baseClient,
-      signerClient,
-      publicClient,
-      {
-        abi: TestTokenABI,
-        account: baseClient.account,
-        address: MOCK_CONTRACT_ADDRESS,
-        chain: anvilAbstractTestnet.chain as ChainEIP712,
-        functionName: 'mint',
-        args: [address.signerAddress, 1n],
-      },
-      address.validatorAddress,
-    ),
+    writeContract(baseClient, signerClient, publicClient, {
+      abi: TestTokenABI,
+      account: baseClient.account,
+      address: MOCK_CONTRACT_ADDRESS,
+      chain: anvilAbstractTestnet.chain as ChainEIP712,
+      functionName: 'mint',
+      args: [address.signerAddress, 1n],
+    }),
   ).rejects.toThrowError(
     'Could not find an Account to execute with this Action',
   );

--- a/packages/agw-client/test/src/constants.ts
+++ b/packages/agw-client/test/src/constants.ts
@@ -50,7 +50,6 @@ export const accounts = [
 export const address = {
   smartAccountAddress: '0x0000000000000000000000000000000000012345',
   signerAddress: '0x8888888888888888888888888888888888888888',
-  validatorAddress: '0x8d9A95c8Dc4736d76a8418A282274f94410D3933',
 } as const;
 
 export const poolId =


### PR DESCRIPTION
This is a constant that doesn't need to be passed around - we can instead reference the constant value.