### PR TITLE
update signer to always return serialized 6492 signature

### DIFF
--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -14,15 +14,20 @@ import {
   hashMessage,
   type Hex,
   parseAbiParameters,
+  serializeErc6492Signature,
   serializeTypedData,
   toHex,
   type Transport,
+  zeroAddress,
 } from 'viem';
 import { toAccount } from 'viem/accounts';
 
 import { createAbstractClient } from './abstractClient.js';
 import { VALIDATOR_ADDRESS } from './constants.js';
-import { getSmartAccountAddressFromInitialSigner } from './utils.js';
+import {
+  getInitializerCalldata,
+  getSmartAccountAddressFromInitialSigner,
+} from './utils.js';
 
 interface TransformEIP1193ProviderOptions {
   provider: EIP1193Provider;
@@ -90,6 +95,17 @@ async function getAgwTypedSignature(
     parseAbiParameters(['bytes', 'address']),
     [rawSignature, VALIDATOR_ADDRESS],
   );
+
+  return serializeErc6492Signature({
+    address: account,
+    data: getInitializerCalldata(signer, VALIDATOR_ADDRESS, {
+      target: zeroAddress,
+      allowFailure: false,
+      callData: '0x',
+      value: 0n,
+    }),
+    signature,
+  });
 
   return signature;
 }


### PR DESCRIPTION
Updates the AGW transformed EIP1193 provider to return a serialized [EIP-6492](https://eips.ethereum.org/EIPS/eip-6492) signature upon `personal_sign` and `eth_signTypedData_v4`

This will ensure that signature verification will always work regardless of deployment status.

Consumers should utilize `viem@2.21.25` or newer (see https://github.com/wevm/viem/pull/2807) for full compatibility of signature verification.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `transformEIP1193Provider` functionality by integrating the `serializeErc6492Signature` method and `getInitializerCalldata` utility, improving the signature transformation process for smart accounts.

### Detailed summary
- Added `serializeErc6492Signature` and `zeroAddress` imports from `viem`.
- Imported `getInitializerCalldata` from `./utils.js`.
- Updated `getAgwTypedSignature` to return a serialized ERC6492 signature using `getInitializerCalldata`.
- Modified tests to use `serializeErc6492Signature` for expected signatures in `personal_sign` and `eth_signTypedData_v4` transformations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->