### PR TITLE
Add `sendPrivyTransaction` for better transaction UIs

### DIFF
--- a/packages/agw-client/src/actions/sendPrivyTransaction.ts
+++ b/packages/agw-client/src/actions/sendPrivyTransaction.ts
@@ -23,6 +23,25 @@ import type { Call } from '../types/call.js';
 
 const ALLOWED_CHAINS: number[] = [abstractTestnet.id];
 
+interface PermissionlessCall {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly to?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly value?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly data?: any;
+}
+
+function convertCallsToPermissionlessCalls(
+  calls?: Call[],
+): PermissionlessCall[] {
+  return (calls || []).map((call) => ({
+    to: call.target,
+    value: call.value,
+    data: call.callData,
+  }));
+}
+
 export async function sendPrivyTransaction<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
   account extends Account | undefined = Account | undefined,
@@ -77,7 +96,11 @@ export async function sendPrivyTransaction<
   return client.request(
     {
       method: 'privy_sendSmartWalletTx',
-      params: [fromAccount, transaction, calls],
+      params: [
+        fromAccount,
+        transaction,
+        convertCallsToPermissionlessCalls(calls),
+      ],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     { retryCount: 0 },

--- a/packages/agw-client/src/actions/sendPrivyTransaction.ts
+++ b/packages/agw-client/src/actions/sendPrivyTransaction.ts
@@ -74,10 +74,12 @@ export async function sendPrivyTransaction<
       chain: chain,
     });
 
-  return client.request({
-    method: 'privy_sendSmartWalletTx',
-    params: [fromAccount, transaction, calls],
-    retries: 0,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any);
+  return client.request(
+    {
+      method: 'privy_sendSmartWalletTx',
+      params: [fromAccount, transaction, calls],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    { retryCount: 0 },
+  );
 }

--- a/packages/agw-client/src/actions/sendPrivyTransaction.ts
+++ b/packages/agw-client/src/actions/sendPrivyTransaction.ts
@@ -1,0 +1,83 @@
+import {
+  type Account,
+  BaseError,
+  type Client,
+  type Transport,
+  type WalletClient,
+} from 'viem';
+import { getChainId } from 'viem/actions';
+import { abstractTestnet } from 'viem/chains';
+import { assertCurrentChain, getAction, parseAccount } from 'viem/utils';
+import {
+  type ChainEIP712,
+  type SignEip712TransactionParameters,
+  type SignEip712TransactionReturnType,
+} from 'viem/zksync';
+
+import {
+  assertEip712Request,
+  type AssertEip712RequestParameters,
+} from '../eip712.js';
+import { AccountNotFoundError } from '../errors/account.js';
+import type { Call } from '../types/call.js';
+
+const ALLOWED_CHAINS: number[] = [abstractTestnet.id];
+
+export async function sendPrivyTransaction<
+  chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  account extends Account | undefined = Account | undefined,
+  chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+>(
+  client: Client<Transport, ChainEIP712, Account>,
+  signerClient: WalletClient<Transport, ChainEIP712, Account>,
+  args: SignEip712TransactionParameters<chain, account, chainOverride>,
+  useSignerAddress = false,
+  calls: Call[] | undefined,
+): Promise<SignEip712TransactionReturnType> {
+  const {
+    account: account_ = client.account,
+    chain = client.chain,
+    ...transaction
+  } = args;
+  // TODO: open up typing to allow for eip712 transactions
+  transaction.type = 'eip712' as any;
+  transaction.value = transaction.value
+    ? BigInt(transaction.value)
+    : (0n as any);
+
+  if (!account_)
+    throw new AccountNotFoundError({
+      docsPath: '/docs/actions/wallet/signTransaction',
+    });
+  const smartAccount = parseAccount(account_);
+  const fromAccount = useSignerAddress ? signerClient.account : smartAccount;
+
+  assertEip712Request({
+    account: smartAccount,
+    chain,
+    ...(transaction as AssertEip712RequestParameters),
+  });
+
+  if (!chain || !ALLOWED_CHAINS.includes(chain.id)) {
+    throw new BaseError('Invalid chain specified');
+  }
+
+  if (!chain?.custom?.getEip712Domain)
+    throw new BaseError('`getEip712Domain` not found on chain.');
+  if (!chain?.serializers?.transaction)
+    throw new BaseError('transaction serializer not found on chain.');
+
+  const chainId = await getAction(client, getChainId, 'getChainId')({});
+  if (chain !== null)
+    assertCurrentChain({
+      currentChainId: chainId,
+      chain: chain,
+    });
+
+  return client.request({
+    method: 'privy_sendSmartWalletTx',
+    params: [fromAccount, transaction, calls],
+    retries: 0,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}

--- a/packages/agw-client/src/actions/sendTransaction.ts
+++ b/packages/agw-client/src/actions/sendTransaction.ts
@@ -146,6 +146,7 @@ export async function sendTransactionBatch<
     publicClient,
     batchTransaction,
     !isDeployed,
+    calls,
   );
 }
 
@@ -200,11 +201,22 @@ export async function sendTransaction<
     parameters.value = 0n;
   }
 
+  const calls: Call[] = [
+    {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      target: parameters.to! as `0x${string}`,
+      allowFailure: false,
+      value: BigInt(parameters.value ?? 0),
+      callData: parameters.data ?? '0x',
+    },
+  ];
+
   return sendTransactionInternal(
     client,
     signerClient,
     publicClient,
     parameters,
     !isDeployed,
+    calls,
   );
 }

--- a/packages/agw-client/src/actions/sendTransactionInternal.ts
+++ b/packages/agw-client/src/actions/sendTransactionInternal.ts
@@ -1,5 +1,6 @@
 import {
   type Account,
+  BaseError,
   type Chain,
   type Client,
   type PublicClient,
@@ -7,7 +8,6 @@ import {
   type Transport,
   type WalletClient,
 } from 'viem';
-import { BaseError } from 'viem';
 import { getChainId } from 'viem/actions';
 import {
   assertCurrentChain,
@@ -27,7 +27,7 @@ import { AccountNotFoundError } from '../errors/account.js';
 import { InsufficientBalanceError } from '../errors/insufficientBalance.js';
 import type { Call } from '../types/call.js';
 import { prepareTransactionRequest } from './prepareTransaction.js';
-import { signTransaction } from './signTransaction.js';
+import { sendPrivyTransaction } from './sendPrivyTransaction.js';
 
 export async function sendTransactionInternal<
   const request extends SendTransactionRequest<chain, chainOverride>,
@@ -79,7 +79,7 @@ export async function sendTransactionInternal<
       });
     }
 
-    return await signTransaction(
+    return await sendPrivyTransaction(
       client,
       signerClient,
       {

--- a/packages/agw-client/src/actions/sendTransactionInternal.ts
+++ b/packages/agw-client/src/actions/sendTransactionInternal.ts
@@ -8,7 +8,7 @@ import {
   type WalletClient,
 } from 'viem';
 import { BaseError } from 'viem';
-import { getChainId, sendRawTransaction } from 'viem/actions';
+import { getChainId } from 'viem/actions';
 import {
   assertCurrentChain,
   getAction,
@@ -25,6 +25,7 @@ import {
 import { INSUFFICIENT_BALANCE_SELECTOR } from '../constants.js';
 import { AccountNotFoundError } from '../errors/account.js';
 import { InsufficientBalanceError } from '../errors/insufficientBalance.js';
+import type { Call } from '../types/call.js';
 import { prepareTransactionRequest } from './prepareTransaction.js';
 import { signTransaction } from './signTransaction.js';
 
@@ -44,6 +45,7 @@ export async function sendTransactionInternal<
     request
   >,
   isInitialTransaction: boolean,
+  calls: Call[] | undefined,
 ): Promise<SendEip712TransactionReturnType> {
   const { chain = client.chain } = parameters;
 
@@ -77,7 +79,7 @@ export async function sendTransactionInternal<
       });
     }
 
-    const serializedTransaction = await signTransaction(
+    return await signTransaction(
       client,
       signerClient,
       {
@@ -85,15 +87,8 @@ export async function sendTransactionInternal<
         chainId,
       } as any,
       isInitialTransaction,
+      calls,
     );
-
-    return await getAction(
-      client,
-      sendRawTransaction,
-      'sendRawTransaction',
-    )({
-      serializedTransaction,
-    });
   } catch (err) {
     if (
       err instanceof Error &&

--- a/packages/agw-client/src/actions/signTransaction.ts
+++ b/packages/agw-client/src/actions/signTransaction.ts
@@ -22,6 +22,7 @@ import {
   type AssertEip712RequestParameters,
 } from '../eip712.js';
 import { AccountNotFoundError } from '../errors/account.js';
+import type { Call } from '../types/call.js';
 
 const ALLOWED_CHAINS: number[] = [abstractTestnet.id];
 
@@ -34,6 +35,7 @@ export async function signTransaction<
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
   args: SignEip712TransactionParameters<chain, account, chainOverride>,
   useSignerAddress = false,
+  calls: Call[] | undefined,
 ): Promise<SignEip712TransactionReturnType> {
   const {
     account: account_ = client.account,
@@ -75,37 +77,8 @@ export async function signTransaction<
       chain: chain,
     });
 
-  const eip712Domain = chain?.custom.getEip712Domain({
-    ...transaction,
-    chainId,
-    from: fromAccount.address,
-    type: 'eip712',
+  return client.request({
+    method: 'privy_sendSmartWalletTx',
+    params: [fromAccount, transaction, calls],
   });
-
-  const rawSignature = await signTypedData(signerClient, {
-    ...eip712Domain,
-    account: signerClient.account,
-  });
-
-  let signature;
-  if (useSignerAddress) {
-    signature = rawSignature;
-  } else {
-    // Match the expect signature format of the AGW smart account
-    signature = encodeAbiParameters(
-      parseAbiParameters(['bytes', 'address', 'bytes[]']),
-      [rawSignature, VALIDATOR_ADDRESS, []],
-    );
-  }
-
-  return chain?.serializers?.transaction(
-    {
-      chainId,
-      ...transaction,
-      from: fromAccount.address,
-      customSignature: signature,
-      type: 'eip712' as any,
-    },
-    { r: '0x0', s: '0x0', v: 0n },
-  ) as SignEip712TransactionReturnType;
 }


### PR DESCRIPTION
PR for using the new RPC method we've added for Abstract, which you can reach via `@privy-io/cross-app-connect@0.0.6-beta-20241015154321`. `privy_sendSmartWalletTx` will sign and transmit smart account transactions. Tested to work with `signTransaction`, `signTransactionBatch`, and `deployContract` from this sdk.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `sendTransaction` functionality by integrating a new method, `sendPrivyTransaction`, and allowing multiple calls to be made in a single transaction.

### Detailed summary
- Added `calls` parameter to `sendTransaction` function.
- Introduced `Call` type and defined `calls` array in `sendTransaction`.
- Replaced `signTransaction` with `sendPrivyTransaction` in `sendTransactionInternal`.
- Created `sendPrivyTransaction` function with support for EIP712 transactions.
- Implemented `convertCallsToPermissionlessCalls` to transform calls for the new transaction method.
- Added error handling for invalid chains and missing domain serializers in `sendPrivyTransaction`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->
Some screenshots: (ignore the Privy image, will be Abstract with your app id)
sendTransaction:
![image](https://github.com/user-attachments/assets/0957b9b3-f628-45f5-89d9-c42c76308b5f)

sendTransactionBatch:
![image](https://github.com/user-attachments/assets/acbccbc9-9aca-40d9-a384-eebe085286e2)
