### PR TITLE
[fix] - typed signatures are now using the correct message hash when transformed to ClaveMessage

### DIFF
--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abstract-foundation/agw-client",
   "description": "Abstract Global Wallet Client SDK",
-  "version": "0.0.1-beta.2",
+  "version": "0.0.1-beta.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -12,6 +12,7 @@ import {
   fromHex,
   type Hash,
   hashMessage,
+  hashTypedData,
   type Hex,
   parseAbiParameters,
   serializeErc6492Signature,
@@ -161,7 +162,7 @@ export function transformEIP1193Provider(
           provider,
           params[0],
           signer,
-          hashMessage(params[1]),
+          hashTypedData(JSON.parse(params[1])),
         );
       }
       case 'personal_sign': {

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -4,6 +4,7 @@ import {
   type EIP1193Provider,
   encodeAbiParameters,
   hashMessage,
+  hashTypedData,
   hexToBytes,
   parseAbiParameters,
   serializeErc6492Signature,
@@ -55,11 +56,11 @@ const exampleTypedData: TypedDataDefinition = {
     contents: 'Hello Bob',
     from: {
       name: 'Alice',
-      wallet: '0x1234',
+      wallet: '0x0000000000000000000000000000000000001234',
     },
     to: {
       name: 'Bob',
-      wallet: '0x5678',
+      wallet: '0x0000000000000000000000000000000000005678',
     },
   },
 };
@@ -414,7 +415,7 @@ describe('transformEIP1193Provider', () => {
         }),
       });
 
-      const messageHash = hashMessage(mockMessage);
+      const messageHash = hashTypedData(JSON.parse(mockMessage));
       (mockProvider.request as Mock).mockResolvedValueOnce(mockAccounts);
       (mockProvider.request as Mock).mockResolvedValueOnce('0x2b74');
       (mockProvider.request as Mock).mockResolvedValueOnce(mockHexSignature);
@@ -453,7 +454,7 @@ describe('transformEIP1193Provider', () => {
         method: 'eth_signTypedData_v4',
         params: [
           mockAccounts[0],
-          `{"domain":{"name":"Ether Mail","version":"1","chainId":11124,"verifyingContract":"0xcccccccccccccccccccccccccccccccccccccccc"},"message":{"contents":"Hello Bob","from":{"name":"Alice","wallet":"0x1234"},"to":{"name":"Bob","wallet":"0x5678"}},"primaryType":"Mail","types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}]}}`,
+          `{"domain":{"name":"Ether Mail","version":"1","chainId":11124,"verifyingContract":"0xcccccccccccccccccccccccccccccccccccccccc"},"message":{"contents":"Hello Bob","from":{"name":"Alice","wallet":"0x0000000000000000000000000000000000001234"},"to":{"name":"Bob","wallet":"0x0000000000000000000000000000000000005678"}},"primaryType":"Mail","types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}]}}`,
         ],
       });
 

--- a/packages/agw-react/package.json
+++ b/packages/agw-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abstract-foundation/agw-react",
   "description": "Abstract Global Wallet React Components",
-  "version": "0.0.1-beta.3",
+  "version": "0.0.1-beta.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the `eth_signTypedMessage_v4` override in the 1193 provider to use the correct message hash when signing.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version numbers of two packages and modifying the `transformEIP1193Provider` function to use `hashTypedData` instead of `hashMessage`, along with updates to the test cases to reflect changes in wallet addresses.

### Detailed summary
- Updated version in `packages/agw-client/package.json` from `0.0.1-beta.2` to `0.0.1-beta.3`.
- Updated version in `packages/agw-react/package.json` from `0.0.1-beta.3` to `0.0.1-beta.4`.
- Changed `hashMessage` to `hashTypedData` in `packages/agw-client/src/transformEIP1193Provider.ts`.
- Updated wallet addresses in `packages/agw-client/test/src/transformEIP1193Provider.test.ts` to include leading zeros.
- Modified the test case to use the updated wallet addresses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->