### PR TITLE
fix imports

### DIFF
--- a/packages/agw-react/src/privy/injectWagmiConnector.tsx
+++ b/packages/agw-react/src/privy/injectWagmiConnector.tsx
@@ -4,7 +4,7 @@ import type { EIP1193Provider, Transport } from 'viem';
 import { useConfig, useReconnect } from 'wagmi';
 import { injected } from 'wagmi/connectors';
 
-import { usePrivyCrossAppProvider } from './usePrivyCrossAppProvider';
+import { usePrivyCrossAppProvider } from './usePrivyCrossAppProvider.js';
 
 interface InjectWagmiConnectorProps extends React.PropsWithChildren {
   testnet: boolean;

--- a/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
+++ b/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
@@ -21,7 +21,7 @@ import {
 } from 'viem';
 import { abstractTestnet } from 'viem/chains';
 
-const AGW_APP_ID = 'cm04asygd041fmry9zmcyn5o5';
+import { AGW_APP_ID } from '../constants.js';
 
 type RpcMethodNames<rpcSchema extends RpcSchema> =
   rpcSchema[keyof rpcSchema] extends { Method: string }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating import statements in the codebase for better clarity and consistency, particularly regarding the `AGW_APP_ID` and the `usePrivyCrossAppProvider` function.

### Detailed summary
- Changed the import of `AGW_APP_ID` from a string constant to a named import from `../constants.js`.
- Updated the import statement for `usePrivyCrossAppProvider` to include the `.js` extension in `packages/agw-react/src/privy/injectWagmiConnector.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->