### PR TITLE
fix 6492

### DIFF
--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abstract-foundation/agw-client",
   "description": "Abstract Global Wallet Client SDK",
-  "version": "0.0.1-beta.3",
+  "version": "0.0.1-beta.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -24,7 +24,10 @@ import {
 import { toAccount } from 'viem/accounts';
 
 import { createAbstractClient } from './abstractClient.js';
-import { VALIDATOR_ADDRESS } from './constants.js';
+import {
+  SMART_ACCOUNT_FACTORY_ADDRESS,
+  VALIDATOR_ADDRESS,
+} from './constants.js';
 import {
   getInitializerCalldata,
   getSmartAccountAddressFromInitialSigner,
@@ -98,7 +101,7 @@ async function getAgwTypedSignature(
   );
 
   return serializeErc6492Signature({
-    address: account,
+    address: SMART_ACCOUNT_FACTORY_ADDRESS,
     data: getInitializerCalldata(signer, VALIDATOR_ADDRESS, {
       target: zeroAddress,
       allowFailure: false,
@@ -107,8 +110,6 @@ async function getAgwTypedSignature(
     }),
     signature,
   });
-
-  return signature;
 }
 
 export function transformEIP1193Provider(

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -18,7 +18,10 @@ import { getGeneralPaymasterInput } from 'viem/zksync';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import * as abstractClientModule from '../../src/abstractClient.js';
-import { VALIDATOR_ADDRESS } from '../../src/constants.js';
+import {
+  SMART_ACCOUNT_FACTORY_ADDRESS,
+  VALIDATOR_ADDRESS,
+} from '../../src/constants.js';
 import { transformEIP1193Provider } from '../../src/transformEIP1193Provider.js';
 import * as utilsModule from '../../src/utils.js';
 import { getInitializerCalldata } from '../../src/utils.js';
@@ -321,7 +324,7 @@ describe('transformEIP1193Provider', () => {
       const mockHexSignature = '0xababcd';
 
       const expectedSignature = serializeErc6492Signature({
-        address: mockSmartAccount,
+        address: SMART_ACCOUNT_FACTORY_ADDRESS,
         signature: encodeAbiParameters(
           parseAbiParameters(['bytes', 'address']),
           [mockHexSignature, VALIDATOR_ADDRESS],
@@ -402,7 +405,7 @@ describe('transformEIP1193Provider', () => {
       const mockHexSignature = '0xababcd';
 
       const expectedSignature = serializeErc6492Signature({
-        address: mockSmartAccount,
+        address: SMART_ACCOUNT_FACTORY_ADDRESS,
         signature: encodeAbiParameters(
           parseAbiParameters(['bytes', 'address']),
           [mockHexSignature, VALIDATOR_ADDRESS],

--- a/packages/agw-react/package.json
+++ b/packages/agw-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abstract-foundation/agw-react",
   "description": "Abstract Global Wallet React Components",
-  "version": "0.0.1-beta.5",
+  "version": "0.0.1-beta.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- **fix imports**
- **[fix] serializeErc6492Signature should get factory address, not account address**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates version numbers and modifies the handling of addresses in the `transformEIP1193Provider` functionality, ensuring the use of `SMART_ACCOUNT_FACTORY_ADDRESS` instead of the previous address.

### Detailed summary
- Updated `version` in `packages/agw-client/package.json` from `0.0.1-beta.3` to `0.0.1-beta.4`.
- Updated `version` in `packages/agw-react/package.json` from `0.0.1-beta.5` to `0.0.1-beta.6`.
- Added `SMART_ACCOUNT_FACTORY_ADDRESS` import in `packages/agw-client/src/transformEIP1193Provider.ts`.
- Changed address in `serializeErc6492Signature` calls from `account` to `SMART_ACCOUNT_FACTORY_ADDRESS`.
- Updated address in `serializeErc6492Signature` calls in `packages/agw-client/test/src/transformEIP1193Provider.test.ts` from `mockSmartAccount` to `SMART_ACCOUNT_FACTORY_ADDRESS`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->