### PR TITLE
Create exported method for creating AGW accounts with no additional calldata

### DIFF
--- a/packages/agw-client/src/actions/deployAccount.ts
+++ b/packages/agw-client/src/actions/deployAccount.ts
@@ -21,13 +21,30 @@ import {
   isSmartAccountDeployed,
 } from '../utils';
 
+export interface DeployAccountParameters {
+  initialSignerAddress: Address;
+  walletClient: WalletClient<Transport, ChainEIP712, Account>;
+  publicClient: PublicClient<Transport, ChainEIP712>;
+  paymaster?: Account;
+  paymasterInput?: Hex;
+}
+
+export interface DeployAccountReturnType {
+  smartAccountAddress: Address;
+  deploymentTransaction: Hash | undefined;
+}
+
 export async function deployAccount(
-  initialSignerAddress: Address,
-  walletClient: WalletClient<Transport, ChainEIP712, Account>,
-  publicClient: PublicClient<Transport, ChainEIP712>,
-  paymaster?: Account,
-  paymasterInput?: Hex,
-) {
+  params: DeployAccountParameters,
+): Promise<DeployAccountReturnType> {
+  const {
+    initialSignerAddress,
+    walletClient,
+    publicClient,
+    paymaster,
+    paymasterInput,
+  } = params;
+
   const address = await getSmartAccountAddressFromInitialSigner(
     initialSignerAddress,
     publicClient,

--- a/packages/agw-client/src/actions/deployAccount.ts
+++ b/packages/agw-client/src/actions/deployAccount.ts
@@ -22,9 +22,9 @@ import {
 } from '../utils';
 
 export interface DeployAccountParameters {
-  initialSignerAddress: Address;
   walletClient: WalletClient<Transport, ChainEIP712, Account>;
   publicClient: PublicClient<Transport, ChainEIP712>;
+  initialSignerAddress?: Address;
   paymaster?: Account;
   paymasterInput?: Hex;
 }
@@ -45,8 +45,10 @@ export async function deployAccount(
     paymasterInput,
   } = params;
 
+  const initialSigner = initialSignerAddress ?? walletClient.account.address;
+
   const address = await getSmartAccountAddressFromInitialSigner(
-    initialSignerAddress,
+    initialSigner,
     publicClient,
   );
 
@@ -55,7 +57,7 @@ export async function deployAccount(
   const isDeployed = await isSmartAccountDeployed(publicClient, address);
   if (!isDeployed) {
     const initializerCallData = getInitializerCalldata(
-      initialSignerAddress,
+      initialSigner,
       VALIDATOR_ADDRESS,
       {
         allowFailure: false,
@@ -64,7 +66,7 @@ export async function deployAccount(
         target: zeroAddress,
       },
     );
-    const addressBytes = toBytes(initialSignerAddress);
+    const addressBytes = toBytes(initialSigner);
     const salt = keccak256(addressBytes);
     const deploymentCalldata = encodeFunctionData({
       abi: AccountFactoryAbi,

--- a/packages/agw-client/src/actions/deployAccount.ts
+++ b/packages/agw-client/src/actions/deployAccount.ts
@@ -1,0 +1,70 @@
+import {
+  type Account,
+  type Address,
+  encodeFunctionData,
+  type Hash,
+  type Hex,
+  keccak256,
+  type PublicClient,
+  toBytes,
+  type Transport,
+  type WalletClient,
+  zeroAddress,
+} from 'viem';
+import type { ChainEIP712 } from 'viem/chains';
+
+import AccountFactoryAbi from '../abis/AccountFactory';
+import { SMART_ACCOUNT_FACTORY_ADDRESS, VALIDATOR_ADDRESS } from '../constants';
+import {
+  getInitializerCalldata,
+  getSmartAccountAddressFromInitialSigner,
+  isSmartAccountDeployed,
+} from '../utils';
+
+export async function deployAccount(
+  initialSignerAddress: Address,
+  walletClient: WalletClient<Transport, ChainEIP712, Account>,
+  publicClient: PublicClient<Transport, ChainEIP712>,
+  paymaster?: Account,
+  paymasterInput?: Hex,
+) {
+  const address = await getSmartAccountAddressFromInitialSigner(
+    initialSignerAddress,
+    publicClient,
+  );
+
+  let deploymentTransaction: Hash | undefined = undefined;
+
+  const isDeployed = await isSmartAccountDeployed(publicClient, address);
+  if (!isDeployed) {
+    const initializerCallData = getInitializerCalldata(
+      initialSignerAddress,
+      VALIDATOR_ADDRESS,
+      {
+        allowFailure: false,
+        callData: '0x',
+        value: 0n,
+        target: zeroAddress,
+      },
+    );
+    const addressBytes = toBytes(initialSignerAddress);
+    const salt = keccak256(addressBytes);
+    const deploymentCalldata = encodeFunctionData({
+      abi: AccountFactoryAbi,
+      functionName: 'deployAccount',
+      args: [salt, initializerCallData],
+    });
+
+    deploymentTransaction = await walletClient.sendTransaction({
+      to: SMART_ACCOUNT_FACTORY_ADDRESS,
+      data: deploymentCalldata,
+      paymaster,
+      paymasterInput,
+    });
+  }
+
+  return {
+    smartAccountAddress: address,
+    deploymentTransaction,
+  };
+}

--- a/packages/agw-client/src/exports/index.ts
+++ b/packages/agw-client/src/exports/index.ts
@@ -2,5 +2,6 @@ export {
   type AbstractClient,
   createAbstractClient,
 } from '../abstractClient.js';
+export { deployAccount } from '../actions/deployAccount.js';
 export { transformEIP1193Provider } from '../transformEIP1193Provider.js';
 export { getSmartAccountAddressFromInitialSigner } from '../utils.js';


### PR DESCRIPTION
- **create account deployment action exported for creating smart accounts**
- **typing**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `deployAccount` function to facilitate the deployment of smart accounts, enhancing the functionality of the client.

### Detailed summary
- Added `deployAccount` function in `packages/agw-client/src/actions/deployAccount.ts`.
- Defined interfaces `DeployAccountParameters` and `DeployAccountReturnType`.
- Implemented logic to check if a smart account is deployed and deploy it if not.
- Exported `deployAccount` from `packages/agw-client/src/exports/index.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->