### PR TITLE
[fix] only use privy_sendSmartWalletTx when using cross-app-connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint:fix": "eslint --fix",
     "prettier-format": "prettier --config .prettierrc './**/*.ts' --write",
     "prettier-check": "prettier --config .prettierrc './**/*.ts' --check",
-    "prepare": "husky"
+    "prepare": "husky",
+    "lint": "pnpm run lint:fix && pnpm run prettier-format"
   },
   "packageManager": "pnpm@9.4.0",
   "lint-staged": {

--- a/packages/agw-client/src/abstractClient.ts
+++ b/packages/agw-client/src/abstractClient.ts
@@ -39,6 +39,7 @@ interface CreateAbstractClientParameters {
    * @optional
    */
   transport?: Transport;
+  isPrivyCrossApp?: boolean;
 }
 
 type AbstractClientActions = AbstractWalletActions<ChainEIP712, Account>;
@@ -50,6 +51,7 @@ export async function createAbstractClient({
   signer,
   chain,
   transport,
+  isPrivyCrossApp = false,
 }: CreateAbstractClientParameters): Promise<AbstractClient> {
   if (!transport) {
     transport = http();
@@ -79,7 +81,7 @@ export async function createAbstractClient({
   });
 
   const abstractClient = baseClient.extend(
-    globalWalletActions(signerWalletClient, publicClient),
+    globalWalletActions(signerWalletClient, publicClient, isPrivyCrossApp),
   );
   return abstractClient as AbstractClient;
 }

--- a/packages/agw-client/src/actions/deployContract.ts
+++ b/packages/agw-client/src/actions/deployContract.ts
@@ -12,7 +12,6 @@ import {
   type DeployContractParameters,
   type DeployContractReturnType,
   encodeDeployData,
-  type SendEip712TransactionParameters,
 } from 'viem/zksync';
 
 import { CONTRACT_DEPLOYER_ADDRESS } from '../constants.js';
@@ -35,6 +34,7 @@ export function deployContract<
     chainOverride,
     allArgs
   >,
+  isPrivyCrossApp = false,
 ): Promise<DeployContractReturnType> {
   const { abi, args, bytecode, deploymentType, salt, ...request } =
     parameters as DeployContractParameters;
@@ -52,13 +52,15 @@ export function deployContract<
   if (!request.factoryDeps.includes(bytecode))
     request.factoryDeps.push(bytecode);
 
-  return sendTransaction(walletClient, signerClient, publicClient, {
-    ...request,
-    data,
-    to: CONTRACT_DEPLOYER_ADDRESS,
-  } as unknown as SendEip712TransactionParameters<
-    chain,
-    account,
-    chainOverride
-  >);
+  return sendTransaction(
+    walletClient,
+    signerClient,
+    publicClient,
+    {
+      ...request,
+      data,
+      to: CONTRACT_DEPLOYER_ADDRESS,
+    },
+    isPrivyCrossApp,
+  );
 }

--- a/packages/agw-client/src/actions/sendTransaction.ts
+++ b/packages/agw-client/src/actions/sendTransaction.ts
@@ -167,6 +167,7 @@ export async function sendTransaction<
     chainOverride,
     request
   >,
+  isPrivyCrossApp = false,
 ): Promise<SendEip712TransactionReturnType> {
   const isDeployed = await isSmartAccountDeployed(
     publicClient,
@@ -206,5 +207,6 @@ export async function sendTransaction<
     publicClient,
     parameters,
     !isDeployed,
+    isPrivyCrossApp,
   );
 }

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -133,7 +133,7 @@ export function transformEIP1193Provider(
     provider,
     chain,
     transport: overrideTransport,
-    isPrivyCrossApp = true,
+    isPrivyCrossApp = false,
   } = options;
 
   const transport = overrideTransport ?? custom(provider);

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -41,6 +41,7 @@ interface TransformEIP1193ProviderOptions {
   provider: EIP1193Provider;
   chain: Chain;
   transport?: Transport;
+  isPrivyCrossApp?: boolean;
 }
 
 async function getAgwAddressFromInitialSigner(
@@ -128,7 +129,12 @@ async function getAgwTypedSignature(
 export function transformEIP1193Provider(
   options: TransformEIP1193ProviderOptions,
 ): EIP1193Provider {
-  const { provider, chain, transport: overrideTransport } = options;
+  const {
+    provider,
+    chain,
+    transport: overrideTransport,
+    isPrivyCrossApp = true,
+  } = options;
 
   const transport = overrideTransport ?? custom(provider);
 
@@ -225,6 +231,7 @@ export function transformEIP1193Provider(
           chain,
           signer,
           transport,
+          isPrivyCrossApp,
         });
 
         // Undo the automatic formatting applied by Wagmi's eth_signTransaction

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -43,6 +43,7 @@ export function globalWalletActions<
 >(
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
   publicClient: PublicClient<Transport, ChainEIP712>,
+  isPrivyCrossApp = false,
 ) {
   return (
     client: Client<Transport, ChainEIP712, Account>,
@@ -52,7 +53,8 @@ export function globalWalletActions<
         client,
         signerClient,
         publicClient,
-        args as SendEip712TransactionParameters<chain, account>,
+        args as any,
+        isPrivyCrossApp,
       ),
     sendTransactionBatch: (args) =>
       sendTransactionBatch(client, signerClient, publicClient, args),
@@ -63,13 +65,20 @@ export function globalWalletActions<
         args as SignEip712TransactionParameters<chain, account>,
       ),
     deployContract: (args) =>
-      deployContract(client, signerClient, publicClient, args),
+      deployContract(client, signerClient, publicClient, args, isPrivyCrossApp),
     writeContract: (args) =>
       writeContract(
         Object.assign(client, {
           sendTransaction: (
             args: SendEip712TransactionParameters<chain, account>,
-          ) => sendTransaction(client, signerClient, publicClient, args),
+          ) =>
+            sendTransaction(
+              client,
+              signerClient,
+              publicClient,
+              args,
+              isPrivyCrossApp,
+            ),
         }),
         signerClient,
         publicClient,

--- a/packages/agw-client/test/src/actions/deployContract.test.ts
+++ b/packages/agw-client/test/src/actions/deployContract.test.ts
@@ -97,6 +97,7 @@ test('create2 with factoryDeps', async () => {
       factoryDeps: [contractBytecode],
       to: CONTRACT_DEPLOYER_ADDRESS,
     },
+    false,
   );
 });
 
@@ -137,5 +138,6 @@ test('create2 with no chain and no account', async () => {
       factoryDeps: [contractBytecode],
       to: CONTRACT_DEPLOYER_ADDRESS,
     },
+    false,
   );
 });

--- a/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
@@ -124,6 +124,7 @@ describe('sendTransaction', () => {
           account: baseClient.account,
           chain: anvilAbstractTestnet.chain as ChainEIP712,
         } as any,
+        false,
       );
 
       if (shouldCallEncodeFunctionData) {
@@ -151,6 +152,7 @@ describe('sendTransaction', () => {
           chain: anvilAbstractTestnet.chain as ChainEIP712,
         }),
         !isDeployed,
+        false,
       );
       expect(transactionHash).toBe('0xmockedTransactionHash');
     },

--- a/packages/agw-client/test/src/walletActions.test.ts
+++ b/packages/agw-client/test/src/walletActions.test.ts
@@ -50,6 +50,7 @@ describe('globalWalletActions', () => {
       mockSignerClient,
       mockPublicClient,
       mockArgs,
+      false,
     );
   });
 
@@ -89,6 +90,7 @@ describe('globalWalletActions', () => {
       mockSignerClient,
       mockPublicClient,
       mockArgs,
+      false,
     );
   });
 

--- a/packages/agw-react/src/abstractWalletConnector.ts
+++ b/packages/agw-react/src/abstractWalletConnector.ts
@@ -74,6 +74,7 @@ function abstractWalletConnector(
       return transformEIP1193Provider({
         provider,
         chain,
+        isPrivyCrossApp: true,
       });
     };
 


### PR DESCRIPTION
- **add flag to indicate if provider supports privy_sendSmartWalletTx**
- **default crossapp to false**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `isPrivyCrossApp` parameter across various functions and tests, allowing for differentiated handling of transactions based on whether they originate from a Privy cross-application context.

### Detailed summary
- Added `isPrivyCrossApp` parameter to several functions including `sendTransaction`, `deployContract`, and `globalWalletActions`.
- Updated `sendTransactionInternal` to handle logic based on `isPrivyCrossApp`.
- Modified tests to account for `isPrivyCrossApp` scenarios.
- Adjusted `transformEIP1193Provider` to accept `isPrivyCrossApp`.
- Enhanced `package.json` scripts for linting and formatting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->