### PR TITLE
[fix] - incorrect type in deployAccount

### DIFF
--- a/packages/agw-client/src/actions/deployAccount.ts
+++ b/packages/agw-client/src/actions/deployAccount.ts
@@ -25,7 +25,7 @@ export interface DeployAccountParameters {
   walletClient: WalletClient<Transport, ChainEIP712, Account>;
   publicClient: PublicClient<Transport, ChainEIP712>;
   initialSignerAddress?: Address;
-  paymaster?: Account;
+  paymaster?: Address;
   paymasterInput?: Hex;
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the type of the `paymaster` property in the `publicClient` interface within the `deployAccount.ts` file from `Account` to `Address`.

### Detailed summary
- Changed the type of `paymaster` from `Account` to `Address` in the `publicClient` interface.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->