### PR TITLE
Update transactions to passthrough privy without lossy serialization

### DIFF
--- a/packages/agw-client/src/actions/sendPrivyTransaction.ts
+++ b/packages/agw-client/src/actions/sendPrivyTransaction.ts
@@ -1,51 +1,20 @@
 import {
   type Account,
-  type Address,
-  BaseError,
   type Client,
+  type SendTransactionRequest,
   type Transport,
-  type WalletClient,
 } from 'viem';
-import { getChainId } from 'viem/actions';
-import { abstractTestnet } from 'viem/chains';
-import { assertCurrentChain, getAction, parseAccount } from 'viem/utils';
 import {
   type ChainEIP712,
-  type SignEip712TransactionParameters,
+  type SendEip712TransactionParameters,
   type SignEip712TransactionReturnType,
 } from 'viem/zksync';
 
-import {
-  assertEip712Request,
-  type AssertEip712RequestParameters,
-} from '../eip712.js';
-import { AccountNotFoundError } from '../errors/account.js';
-import type { Call } from '../types/call.js';
-
-const ALLOWED_CHAINS: number[] = [abstractTestnet.id];
-
-interface PermissionlessCall {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly to?: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly value?: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly data?: any;
-}
-
-function convertCallsToPermissionlessCalls(
-  calls?: Call[],
-): PermissionlessCall[] {
-  return (calls || []).map((call) => ({
-    to: call.target,
-    value: call.value.toString(),
-    data: call.callData,
-  }));
-}
+import type { SendTransactionBatchParameters } from '../types/sendTransactionBatch';
 
 function convertBigIntToString(obj: any): any {
   if (typeof obj === 'bigint') {
-    return obj.toString();
+    return '0x' + obj.toString(16); // Convert BigInt to hex string
   }
   if (typeof obj !== 'object' || obj === null) {
     return obj;
@@ -65,75 +34,23 @@ export async function sendPrivyTransaction<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
   account extends Account | undefined = Account | undefined,
   chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  const request extends SendTransactionRequest<
+    chain,
+    chainOverride
+  > = SendTransactionRequest<chain, chainOverride>,
 >(
   client: Client<Transport, ChainEIP712, Account>,
-  signerClient: WalletClient<Transport, ChainEIP712, Account>,
-  args: SignEip712TransactionParameters<chain, account, chainOverride>,
-  useSignerAddress = false,
+  parameters:
+    | SendEip712TransactionParameters<chain, account, chainOverride, request>
+    | SendTransactionBatchParameters<request>,
 ): Promise<SignEip712TransactionReturnType> {
-  const {
-    account: account_ = client.account,
-    chain = client.chain,
-    ...transaction
-  } = args;
-  // TODO: open up typing to allow for eip712 transactions
-  transaction.type = 'eip712' as any;
-  transaction.value = transaction.value
-    ? BigInt(transaction.value)
-    : (0n as any);
-
-  if (!account_)
-    throw new AccountNotFoundError({
-      docsPath: '/docs/actions/wallet/signTransaction',
-    });
-  const smartAccount = parseAccount(account_);
-  const fromAccount = useSignerAddress ? signerClient.account : smartAccount;
-
-  assertEip712Request({
-    account: smartAccount,
-    chain,
-    ...(transaction as AssertEip712RequestParameters),
-  });
-
-  if (!chain || !ALLOWED_CHAINS.includes(chain.id)) {
-    throw new BaseError('Invalid chain specified');
-  }
-
-  if (!chain?.custom?.getEip712Domain)
-    throw new BaseError('`getEip712Domain` not found on chain.');
-  if (!chain?.serializers?.transaction)
-    throw new BaseError('transaction serializer not found on chain.');
-
-  const chainId = await getAction(client, getChainId, 'getChainId')({});
-  if (chain !== null)
-    assertCurrentChain({
-      currentChainId: chainId,
-      chain: chain,
-    });
-
-  const calls: Call[] = [
-    {
-      target: transaction.to as Address,
-      allowFailure: false,
-      value: BigInt(transaction.value ?? 0),
-      callData: transaction.data ?? '0x',
-    },
-  ];
-
-  const serializedTransaction = convertBigIntToString(transaction);
-
   const result = (await client.request(
     {
       method: 'privy_sendSmartWalletTx',
-      params: [
-        fromAccount,
-        serializedTransaction,
-        convertCallsToPermissionlessCalls(calls),
-      ],
+      params: [convertBigIntToString(parameters)],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     { retryCount: 0 },
   )) as any;
-
   return result;
 }

--- a/packages/agw-client/src/actions/sendTransactionInternal.ts
+++ b/packages/agw-client/src/actions/sendTransactionInternal.ts
@@ -26,7 +26,6 @@ import { INSUFFICIENT_BALANCE_SELECTOR } from '../constants.js';
 import { AccountNotFoundError } from '../errors/account.js';
 import { InsufficientBalanceError } from '../errors/insufficientBalance.js';
 import { prepareTransactionRequest } from './prepareTransaction.js';
-import { sendPrivyTransaction } from './sendPrivyTransaction.js';
 import { signTransaction } from './signTransaction.js';
 
 export async function sendTransactionInternal<
@@ -45,7 +44,6 @@ export async function sendTransactionInternal<
     request
   >,
   isInitialTransaction: boolean,
-  isPrivyCrossApp = false,
 ): Promise<SendEip712TransactionReturnType> {
   const { chain = client.chain } = parameters;
 
@@ -79,34 +77,22 @@ export async function sendTransactionInternal<
       });
     }
 
-    if (isPrivyCrossApp) {
-      return await sendPrivyTransaction(
-        client,
-        signerClient,
-        {
-          ...request,
-          chainId,
-        } as any,
-        isInitialTransaction,
-      );
-    } else {
-      const serializedTransaction = await signTransaction(
-        client,
-        signerClient,
-        {
-          ...request,
-          chainId,
-        } as any,
-        isInitialTransaction,
-      );
-      return await getAction(
-        client,
-        sendRawTransaction,
-        'sendRawTransaction',
-      )({
-        serializedTransaction,
-      });
-    }
+    const serializedTransaction = await signTransaction(
+      client,
+      signerClient,
+      {
+        ...request,
+        chainId,
+      } as any,
+      isInitialTransaction,
+    );
+    return await getAction(
+      client,
+      sendRawTransaction,
+      'sendRawTransaction',
+    )({
+      serializedTransaction,
+    });
   } catch (err) {
     if (
       err instanceof Error &&

--- a/packages/agw-client/src/types/sendTransactionBatch.ts
+++ b/packages/agw-client/src/types/sendTransactionBatch.ts
@@ -1,0 +1,17 @@
+import type {
+  Account,
+  Address,
+  Chain,
+  Hex,
+  SendTransactionRequest,
+} from 'viem';
+import type { SendEip712TransactionParameters } from 'viem/zksync';
+
+export interface SendTransactionBatchParameters<
+  request extends SendTransactionRequest<Chain> = SendTransactionRequest<Chain>,
+> {
+  // TODO: figure out if more fields need to be lifted up
+  calls: SendEip712TransactionParameters<Chain, Account, Chain, request>[];
+  paymaster?: Address | undefined;
+  paymasterInput?: Hex | undefined;
+}

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -21,10 +21,10 @@ import { deployContract } from './actions/deployContract.js';
 import {
   sendTransaction,
   sendTransactionBatch,
-  type SendTransactionBatchParameters,
 } from './actions/sendTransaction.js';
 import { signTransaction } from './actions/signTransaction.js';
 import { writeContract } from './actions/writeContract.js';
+import type { SendTransactionBatchParameters } from './types/sendTransactionBatch.js';
 
 export type AbstractWalletActions<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
@@ -57,7 +57,13 @@ export function globalWalletActions<
         isPrivyCrossApp,
       ),
     sendTransactionBatch: (args) =>
-      sendTransactionBatch(client, signerClient, publicClient, args),
+      sendTransactionBatch(
+        client,
+        signerClient,
+        publicClient,
+        args,
+        isPrivyCrossApp,
+      ),
     signTransaction: (args) =>
       signTransaction(
         client,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the transaction batching functionality by introducing the `SendTransactionBatchParameters` interface and refining the `sendTransactionBatch` and `sendPrivyTransaction` methods to support this new structure.

### Detailed summary
- Added `SendTransactionBatchParameters` interface in `sendTransactionBatch.ts`.
- Updated `walletActions.ts` to import and utilize `SendTransactionBatchParameters`.
- Refactored `sendTransactionBatch` function to handle `isPrivyCrossApp` logic.
- Removed legacy handling of `isPrivyCrossApp` from `sendTransactionInternal`.
- Modified `sendPrivyTransaction` to accept `SendTransactionBatchParameters` as an argument.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->