### PR TITLE
always pass walletclient account to deployment tx

### DIFF
--- a/packages/agw-client/src/actions/deployAccount.ts
+++ b/packages/agw-client/src/actions/deployAccount.ts
@@ -75,6 +75,7 @@ export async function deployAccount(
     });
 
     deploymentTransaction = await walletClient.sendTransaction({
+      account: walletClient.account,
       to: SMART_ACCOUNT_FACTORY_ADDRESS,
       data: deploymentCalldata,
       paymaster,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `sendTransaction` method in the `deployAccount.ts` file to include the `account` property from `walletClient`.

### Detailed summary
- Added `account: walletClient.account` to the object passed to `walletClient.sendTransaction` in `deployAccount.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->