### PR TITLE
export constants from agw-client

### DIFF
--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -28,6 +28,18 @@
       "types": "./dist/types/exports/index.d.ts",
       "import": "./dist/esm/exports/index.js",
       "require": "./dist/cjs/exports/index.js"
+    },
+    "./constants": {
+      "types": "./dist/types/exports/constants.d.ts",
+      "import": "./dist/esm/exports/constants.js",
+      "require": "./dist/cjs/exports/constants.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "constants": [
+        "./dist/types/exports/constants.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/agw-client/src/exports/constants.ts
+++ b/packages/agw-client/src/exports/constants.ts
@@ -1,0 +1,11 @@
+import {
+  BATCH_CALLER_ADDRESS,
+  SMART_ACCOUNT_FACTORY_ADDRESS,
+  VALIDATOR_ADDRESS,
+} from '../constants.js';
+
+export {
+  BATCH_CALLER_ADDRESS as batchCallerAddress,
+  SMART_ACCOUNT_FACTORY_ADDRESS as smartAccountFactoryAddress,
+  VALIDATOR_ADDRESS as validatorAddress,
+};


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on exporting constants from the `constants.ts` file in the `agw-client` package and updating the `package.json` to include type definitions and module paths for these constants.

### Detailed summary
- Added imports for `BATCH_CALLER_ADDRESS`, `SMART_ACCOUNT_FACTORY_ADDRESS`, and `VALIDATOR_ADDRESS` from `../constants.js` in `constants.ts`.
- Exported these constants with new aliases: `batchCallerAddress`, `smartAccountFactoryAddress`, and `validatorAddress`.
- Updated `package.json` to include paths for `constants` in the `files` and `typesVersions` sections.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->