### PR TITLE
fix: Update signTransaction to always convert hex values to bigints if hex is passed in

### DIFF
--- a/packages/agw-client/src/actions/signTransaction.ts
+++ b/packages/agw-client/src/actions/signTransaction.ts
@@ -22,6 +22,7 @@ import {
   type AssertEip712RequestParameters,
 } from '../eip712.js';
 import { AccountNotFoundError } from '../errors/account.js';
+import { transformHexValues } from '../utils.js';
 
 const ALLOWED_CHAINS: number[] = [abstractTestnet.id];
 
@@ -42,9 +43,15 @@ export async function signTransaction<
   } = args;
   // TODO: open up typing to allow for eip712 transactions
   transaction.type = 'eip712' as any;
-  transaction.value = transaction.value
-    ? BigInt(transaction.value)
-    : (0n as any);
+  transformHexValues(transaction, [
+    'value',
+    'nonce',
+    'maxPriorityFeePerGas',
+    'gas',
+    'value',
+    'chainId',
+    'gasPerPubdata',
+  ]);
 
   if (!account_)
     throw new AccountNotFoundError({

--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -1,7 +1,9 @@
 import {
   type Address,
   encodeFunctionData,
+  fromHex,
   type Hex,
+  isHex,
   keccak256,
   type PublicClient,
   toBytes,
@@ -99,4 +101,13 @@ export function getInitializerCalldata(
     functionName: 'initialize',
     args: [initialOwnerAddress, validatorAddress, [], initialCall],
   });
+}
+
+export function transformHexValues(transaction: any, keys: string[]) {
+  if (!transaction) return;
+  for (const key of keys) {
+    if (isHex(transaction[key])) {
+      transaction[key] = fromHex(transaction[key], 'bigint');
+    }
+  }
 }

--- a/packages/agw-client/test/src/actions/signTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/signTransaction.test.ts
@@ -56,6 +56,22 @@ const transaction: ZksyncTransactionRequestEIP712 = {
   paymasterInput: '0x',
 };
 
+const transactionWithBigIntValues = {
+  value: 1n,
+  nonce: 2n,
+  maxPriorityFeePerGas: 3n,
+  gas: 4n,
+  gasPerPubdata: 5n,
+};
+
+const transactionWithHexValues = {
+  value: '0x1',
+  nonce: '0x2',
+  maxPriorityFeePerGas: '0x3',
+  gas: '0x4',
+  gasPerPubdata: '0x5',
+};
+
 test('with useSignerAddress false', async () => {
   const signature = encodeAbiParameters(
     parseAbiParameters(['bytes', 'address', 'bytes[]']),
@@ -115,6 +131,36 @@ test('with useSignerAddress true', async () => {
     true,
   );
   expect(signedTransaction).toBe(expectedSignedTransaction);
+});
+
+test('handles hex values', async () => {
+  const signedTransactionWithHexValues = await signTransaction(
+    baseClient,
+    signerClient,
+    {
+      ...transactionWithHexValues,
+      type: 'eip712',
+      account: baseClient.account,
+      chain: anvilAbstractTestnet.chain as ChainEIP712,
+    } as any,
+    false,
+  );
+
+  const signedTransactionWithBigIntValues = await signTransaction(
+    baseClient,
+    signerClient,
+    {
+      ...transactionWithBigIntValues,
+      type: 'eip712',
+      account: baseClient.account,
+      chain: anvilAbstractTestnet.chain as ChainEIP712,
+    } as any,
+    false,
+  );
+
+  expect(signedTransactionWithHexValues).toBe(
+    signedTransactionWithBigIntValues,
+  );
 });
 
 test('invalid chain', async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new utility function to transform hex string values in transactions to `bigint`, enhancing the handling of transaction data in the `signTransaction` function.

### Detailed summary
- Added `transformHexValues` function in `utils.ts` to convert hex strings to `bigint`.
- Integrated `transformHexValues` into `signTransaction` to process specific transaction fields.
- Created tests to validate handling of hex values in `signTransaction`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->