### PR TITLE
fix: sanitize maxFeePerGas from hex when processing transaction parameters

### DIFF
--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abstract-foundation/agw-client",
   "description": "Abstract Global Wallet Client SDK",
-  "version": "0.0.1-beta.14",
+  "version": "0.0.1-beta.15",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/agw-client/src/actions/signTransaction.ts
+++ b/packages/agw-client/src/actions/signTransaction.ts
@@ -46,6 +46,7 @@ export async function signTransaction<
   transformHexValues(transaction, [
     'value',
     'nonce',
+    'maxFeePerGas',
     'maxPriorityFeePerGas',
     'gas',
     'value',

--- a/packages/agw-client/test/src/actions/signTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/signTransaction.test.ts
@@ -62,6 +62,7 @@ const transactionWithBigIntValues = {
   maxPriorityFeePerGas: 3n,
   gas: 4n,
   gasPerPubdata: 5n,
+  maxFeePerGas: 6n,
 };
 
 const transactionWithHexValues = {
@@ -70,6 +71,7 @@ const transactionWithHexValues = {
   maxPriorityFeePerGas: '0x3',
   gas: '0x4',
   gasPerPubdata: '0x5',
+  maxFeePerGas: '0x6',
 };
 
 test('with useSignerAddress false', async () => {

--- a/packages/agw-react/package.json
+++ b/packages/agw-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abstract-foundation/agw-react",
   "description": "Abstract Global Wallet React Components",
-  "version": "0.0.1-beta.13",
+  "version": "0.0.1-beta.14",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- **sanitize maxFeePerGas on signature**
- **bump versions**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `agw-client` and `agw-react` packages, enhancing the transaction parameters to include `maxFeePerGas` and `maxPriorityFeePerGas`, and updating corresponding test cases.

### Detailed summary
- Added `maxFeePerGas` and `maxPriorityFeePerGas` to the `signTransaction.ts` file.
- Updated the version of `@abstract-foundation/agw-client` from `0.0.1-beta.14` to `0.0.1-beta.15`.
- Updated the version of `@abstract-foundation/agw-react` from `0.0.1-beta.13` to `0.0.1-beta.14`.
- Included `maxFeePerGas` in the `transactionWithHexValues` test case.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->