### PR TITLE
fix: encode result of passthru 712 transaction to confirm with AGW contract spec

### DIFF
--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -188,10 +188,17 @@ export function transformEIP1193Provider(
           parsedTypedData?.domain?.name === 'zkSync' &&
           isEIP712Transaction(parsedTypedData.message as any)
         ) {
-          return provider.request({
+          const rawSignature = await provider.request({
             method: 'eth_signTypedData_v4',
             params: [signer, params[1]],
           });
+          // Match the expect signature format of the AGW smart account so the result can be
+          // directly used in eth_sendRawTransaction as the customSignature field
+          const signature = encodeAbiParameters(
+            parseAbiParameters(['bytes', 'address', 'bytes[]']),
+            [rawSignature, VALIDATOR_ADDRESS, []],
+          );
+          return signature;
         }
 
         return await getAgwTypedSignature(

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -1,6 +1,5 @@
 import {
   Address,
-  createPublicClient,
   decodeAbiParameters,
   type EIP1193EventMap,
   type EIP1193Provider,
@@ -10,7 +9,6 @@ import {
   hashMessage,
   hashTypedData,
   hexToBytes,
-  http,
   keccak256,
   parseAbiParameters,
   serializeErc6492Signature,
@@ -20,7 +18,6 @@ import {
   TypedDataDefinition,
   zeroAddress,
 } from 'viem';
-import { getEip712Domain } from 'viem/actions';
 import { abstractTestnet } from 'viem/chains';
 import { getGeneralPaymasterInput } from 'viem/zksync';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -1,6 +1,7 @@
 import {
   Address,
   createPublicClient,
+  decodeAbiParameters,
   type EIP1193EventMap,
   type EIP1193Provider,
   encodeAbiParameters,
@@ -528,7 +529,14 @@ describe('transformEIP1193Provider', () => {
         params: [mockAccounts[0], message],
       });
 
-      expect(result).toBe(mockHexSignature);
+      const [rawSignature, validatorAddress, hookData] = decodeAbiParameters(
+        parseAbiParameters(['bytes', 'address', 'bytes[]']),
+        result,
+      );
+
+      expect(rawSignature).toBe(mockHexSignature);
+      expect(validatorAddress).toBe(VALIDATOR_ADDRESS);
+      expect(hookData).toEqual([]);
     });
 
     it('should pass through eth_signTypedData_v4 to original provider for signer wallet', async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `transformEIP1193Provider` by adding signature encoding functionality to match the expected format for AGW smart accounts.

### Detailed summary
- Replaced the return of `provider.request` with an `await` for `provider.request` to get `rawSignature`.
- Added encoding of `rawSignature` into the expected signature format using `encodeAbiParameters`.
- Updated the test to decode and assert the structure of the resulting signature, validating `rawSignature`, `validatorAddress`, and `hookData`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->