### PR TITLE
fix: custom provider should always be passed into transformEIP1193Provider for privy connection

### DIFF
--- a/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
+++ b/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
@@ -11,6 +11,7 @@ import { useCallback, useMemo } from 'react';
 import {
   type Address,
   createPublicClient,
+  custom,
   type EIP1193Provider,
   type EIP1193RequestFn,
   type EIP1474Methods,
@@ -199,7 +200,7 @@ export const usePrivyCrossAppProvider = ({
   const wrappedProvider = transformEIP1193Provider({
     chain,
     provider,
-    transport,
+    transport: custom(provider),
   });
 
   return {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the `usePrivyCrossAppProvider` function to allow for a customizable transport layer by replacing the `transport` parameter with a call to `custom(provider)`.

### Detailed summary
- Updated the `usePrivyCrossAppProvider` function.
- Changed the `transport` parameter to use `custom(provider)` instead of the previous `transport` value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->