### PR TITLE
Move prepare transaction into client

### DIFF
--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -244,11 +244,14 @@ export type PrepareTransactionRequestErrorType =
  * })
  */
 export async function prepareTransactionRequest<
-  const request extends PrepareTransactionRequestRequest<chain, chainOverride>,
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
   account extends Account | undefined = Account | undefined,
   accountOverride extends Account | Address | undefined = undefined,
   chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  const request extends PrepareTransactionRequestRequest<
+    chain,
+    chainOverride
+  > = PrepareTransactionRequestRequest<chain, chainOverride>,
 >(
   client: Client<Transport, ChainEIP712, Account>,
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
@@ -260,17 +263,14 @@ export async function prepareTransactionRequest<
     accountOverride,
     request
   >,
-  isInitialTransaction: boolean,
-): Promise<
-  PrepareTransactionRequestReturnType<
-    chain,
-    account,
-    chainOverride,
-    accountOverride,
-    request
-  >
-> {
+  isInitialTransaction?: boolean,
+): Promise<PrepareTransactionRequestReturnType> {
   const { chain, gas, nonce, parameters = defaultParameters } = args;
+  if (isInitialTransaction === undefined) {
+    // TODO Determine if initial transaction and prep as such in here!
+    isInitialTransaction = false;
+  }
+
   const initiatorAccount = parseAccount(
     isInitialTransaction ? signerClient.account : client.account,
   );

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -124,6 +124,11 @@ export type PrepareTransactionRequestRequest<
      * @default ['blobVersionedHashes', 'chainId', 'fees', 'gas', 'nonce', 'type']
      */
     parameters?: readonly PrepareTransactionRequestParameterType[] | undefined;
+
+    /**
+     * Whether the transaction is the first transaction of the account.
+     */
+    isInitialTransaction?: boolean;
   };
 
 export type PrepareTransactionRequestParameters<
@@ -141,7 +146,9 @@ export type PrepareTransactionRequestParameters<
 > = request &
   GetAccountParameter<account, accountOverride, false> &
   GetChainParameter<chain, chainOverride> &
-  GetTransactionRequestKzgParameter<request> & { chainId?: number | undefined };
+  GetTransactionRequestKzgParameter<request> & {
+    chainId?: number | undefined;
+  };
 
 export type PrepareTransactionRequestReturnType<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
@@ -263,16 +270,17 @@ export async function prepareTransactionRequest<
     accountOverride,
     request
   >,
-  isInitialTransaction?: boolean,
 ): Promise<PrepareTransactionRequestReturnType> {
-  const { chain, gas, nonce, parameters = defaultParameters } = args;
-  if (isInitialTransaction === undefined) {
-    // TODO Determine if initial transaction and prep as such in here!
-    isInitialTransaction = false;
-  }
+  const {
+    isInitialTransaction,
+    chain,
+    gas,
+    nonce,
+    parameters = defaultParameters,
+  } = args;
 
   const initiatorAccount = parseAccount(
-    isInitialTransaction ? signerClient.account : client.account,
+    (isInitialTransaction ?? false) ? signerClient.account : client.account,
   );
   const request = {
     ...args,
@@ -369,6 +377,7 @@ export async function prepareTransactionRequest<
   assertRequest(request as AssertRequestParameters);
 
   delete request.parameters;
+  delete request.isInitialTransaction;
 
   return request as any;
 }

--- a/packages/agw-client/src/actions/sendTransactionInternal.ts
+++ b/packages/agw-client/src/actions/sendTransactionInternal.ts
@@ -64,8 +64,8 @@ export async function sendTransactionInternal<
       {
         ...parameters,
         parameters: ['gas', 'nonce', 'fees'],
+        isInitialTransaction,
       } as any,
-      isInitialTransaction,
     );
 
     let chainId: number | undefined;

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -4,8 +4,6 @@ import {
   type Address,
   type Chain,
   type Client,
-  type PrepareTransactionRequestParameters,
-  type PrepareTransactionRequestRequest,
   type PrepareTransactionRequestReturnType,
   type PublicClient,
   type SendTransactionRequest,
@@ -22,7 +20,11 @@ import {
 } from 'viem/zksync';
 
 import { deployContract } from './actions/deployContract.js';
-import { prepareTransactionRequest } from './actions/prepareTransaction.js';
+import {
+  prepareTransactionRequest,
+  type PrepareTransactionRequestParameters,
+  type PrepareTransactionRequestRequest,
+} from './actions/prepareTransaction.js';
 import {
   sendTransaction,
   sendTransactionBatch,

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -1,8 +1,12 @@
 import {
   type Abi,
   type Account,
+  type Address,
   type Chain,
   type Client,
+  type PrepareTransactionRequestParameters,
+  type PrepareTransactionRequestRequest,
+  type PrepareTransactionRequestReturnType,
   type PublicClient,
   type SendTransactionRequest,
   type SendTransactionReturnType,
@@ -18,6 +22,7 @@ import {
 } from 'viem/zksync';
 
 import { deployContract } from './actions/deployContract.js';
+import { prepareTransactionRequest } from './actions/prepareTransaction.js';
 import {
   sendTransaction,
   sendTransactionBatch,
@@ -35,6 +40,24 @@ export type AbstractWalletActions<
   >(
     args: SendTransactionBatchParameters<request>,
   ) => Promise<SendTransactionReturnType>;
+  prepareTransactionRequest: <
+    chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+    account extends Account | undefined = Account | undefined,
+    accountOverride extends Account | Address | undefined = undefined,
+    chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+    const request extends PrepareTransactionRequestRequest<
+      chain,
+      chainOverride
+    > = PrepareTransactionRequestRequest<chain, chainOverride>,
+  >(
+    args: PrepareTransactionRequestParameters<
+      chain,
+      account,
+      chainOverride,
+      accountOverride,
+      request
+    >,
+  ) => Promise<PrepareTransactionRequestReturnType>;
 };
 
 export function globalWalletActions<
@@ -48,6 +71,13 @@ export function globalWalletActions<
   return (
     client: Client<Transport, ChainEIP712, Account>,
   ): AbstractWalletActions<Chain, Account> => ({
+    prepareTransactionRequest: (args) =>
+      prepareTransactionRequest(
+        client,
+        signerClient,
+        publicClient,
+        args as any,
+      ),
     sendTransaction: (args) =>
       sendTransaction(
         client,

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -42,7 +42,7 @@ export type AbstractWalletActions<
   >(
     args: SendTransactionBatchParameters<request>,
   ) => Promise<SendTransactionReturnType>;
-  prepareTransactionRequest: <
+  prepareAbstractTransactionRequest: <
     chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
     account extends Account | undefined = Account | undefined,
     accountOverride extends Account | Address | undefined = undefined,
@@ -73,7 +73,7 @@ export function globalWalletActions<
   return (
     client: Client<Transport, ChainEIP712, Account>,
   ): AbstractWalletActions<Chain, Account> => ({
-    prepareTransactionRequest: (args) =>
+    prepareAbstractTransactionRequest: (args) =>
       prepareTransactionRequest(
         client,
         signerClient,

--- a/packages/agw-client/test/src/abstractClient.test.ts
+++ b/packages/agw-client/test/src/abstractClient.test.ts
@@ -60,6 +60,7 @@ describe('createAbstractClient', () => {
       'signTransaction',
       'deployContract',
       'writeContract',
+      'prepareTransactionRequest',
     ].forEach((prop) => {
       expect(abstractClient).toHaveProperty(prop);
     });

--- a/packages/agw-client/test/src/abstractClient.test.ts
+++ b/packages/agw-client/test/src/abstractClient.test.ts
@@ -20,6 +20,7 @@ vi.mock('viem', async () => {
         signTransaction: vi.fn(),
         deployContract: vi.fn(),
         writeContract: vi.fn(),
+        prepareAbstractTransactionRequest: vi.fn(),
       }),
     }),
     createPublicClient: vi.fn(),
@@ -60,7 +61,7 @@ describe('createAbstractClient', () => {
       'signTransaction',
       'deployContract',
       'writeContract',
-      'prepareTransactionRequest',
+      'prepareAbstractTransactionRequest',
     ].forEach((prop) => {
       expect(abstractClient).toHaveProperty(prop);
     });

--- a/packages/agw-client/test/src/actions/prepareTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/prepareTransaction.test.ts
@@ -90,8 +90,8 @@ test('minimum', async () => {
     {
       ...transaction,
       chain: anvilAbstractTestnet.chain,
+      isInitialTransaction: false,
     },
-    false,
   );
   expect(request).toEqual({
     ...transaction,
@@ -113,8 +113,8 @@ test('is initial transaction', async () => {
     {
       ...transaction,
       chain: anvilAbstractTestnet.chain,
+      isInitialTransaction: true,
     },
-    true,
   );
   expect(request).toEqual({
     ...transaction,
@@ -138,8 +138,8 @@ test('with fees', async () => {
       maxFeePerGas: 10000n,
       maxPriorityFeePerGas: 0n,
       chain: anvilAbstractTestnet.chain,
+      isInitialTransaction: false,
     },
-    false,
   );
   expect(request).toEqual({
     ...transaction,
@@ -162,8 +162,8 @@ test('to contract deployer', async () => {
       ...transaction,
       to: CONTRACT_DEPLOYER_ADDRESS,
       chain: anvilAbstractTestnet.chain,
+      isInitialTransaction: false,
     },
-    false,
   );
   expect(request).toEqual({
     ...transaction,
@@ -187,7 +187,6 @@ test('with chainId but not chain', async () => {
       chainId: anvilAbstractTestnet.chain.id,
       ...transaction,
     } as any,
-    false,
   );
   expect(request).toEqual({
     ...transaction,
@@ -206,7 +205,6 @@ test('with no chainId or chain', async () => {
     signerClient,
     publicClient,
     transaction as any,
-    false,
   );
   expect(request).toEqual({
     ...transaction,
@@ -238,16 +236,10 @@ test('throws if maxFeePerGas is too low', async () => {
   }) as EIP1193RequestFn;
 
   await expect(
-    prepareTransactionRequest(
-      baseClient,
-      signerClient,
-      publicClientModified,
-      {
-        ...transaction,
-        chain: anvilAbstractTestnet.chain,
-        maxFeePerGas: 10000n,
-      },
-      false,
-    ),
+    prepareTransactionRequest(baseClient, signerClient, publicClientModified, {
+      ...transaction,
+      chain: anvilAbstractTestnet.chain,
+      maxFeePerGas: 10000n,
+    }),
   ).rejects.toThrow(MaxFeePerGasTooLowError);
 });

--- a/packages/agw-client/test/src/walletActions.test.ts
+++ b/packages/agw-client/test/src/walletActions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import * as deployContractModule from '../../src/actions/deployContract.js';
+import * as prepareTransactionRequestModule from '../../src/actions/prepareTransaction.js';
 import * as sendTransactionModule from '../../src/actions/sendTransaction.js';
 import * as signTransactionModule from '../../src/actions/signTransaction.js';
 import * as writeContractModule from '../../src/actions/writeContract.js';
@@ -12,6 +13,7 @@ vi.mock('../../src/actions/sendTransaction');
 vi.mock('../../src/actions/signTransaction');
 vi.mock('../../src/actions/deployContract');
 vi.mock('../../src/actions/writeContract');
+vi.mock('../../src/actions/prepareTransaction');
 
 describe('globalWalletActions', () => {
   const mockSignerClient = {
@@ -107,6 +109,23 @@ describe('globalWalletActions', () => {
       expect.objectContaining({
         sendTransaction: expect.any(Function),
       }),
+      mockSignerClient,
+      mockPublicClient,
+      mockArgs,
+    );
+  });
+
+  it('should call prepareTransaction with correct arguments', async () => {
+    const mockArgs = {
+      to: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+      value: 100n,
+      isInitialTransaction: true,
+    };
+    await actions.prepareTransactionRequest(mockArgs as any);
+    expect(
+      prepareTransactionRequestModule.prepareTransactionRequest,
+    ).toHaveBeenCalledWith(
+      mockClient,
       mockSignerClient,
       mockPublicClient,
       mockArgs,

--- a/packages/agw-client/test/src/walletActions.test.ts
+++ b/packages/agw-client/test/src/walletActions.test.ts
@@ -121,7 +121,7 @@ describe('globalWalletActions', () => {
       value: 100n,
       isInitialTransaction: true,
     };
-    await actions.prepareTransactionRequest(mockArgs as any);
+    await actions.prepareAbstractTransactionRequest(mockArgs as any);
     expect(
       prepareTransactionRequestModule.prepareTransactionRequest,
     ).toHaveBeenCalledWith(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `isInitialTransaction` parameter to the transaction preparation process, enhancing functionality in transaction handling. It also adds tests to ensure this new feature works correctly across various modules.

### Detailed summary
- Added `isInitialTransaction` parameter to `prepareTransactionRequest`.
- Updated `sendTransactionInternal` to include `isInitialTransaction`.
- Introduced `prepareAbstractTransactionRequest` function in `walletActions`.
- Added tests for `prepareAbstractTransactionRequest` in `walletActions.test.ts`.
- Updated type definitions in `prepareTransaction.ts` to accommodate `isInitialTransaction`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->