### PR TITLE
feat: Send privy sign message and sign typed data to cross app raw

### DIFF
--- a/packages/agw-client/src/actions/sendPrivyTransaction.ts
+++ b/packages/agw-client/src/actions/sendPrivyTransaction.ts
@@ -38,7 +38,7 @@ export async function sendPrivyTransaction<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     { retryCount: 0 },
-  )) as any;
+  )) as SignEip712TransactionReturnType;
   return result;
 }
 
@@ -53,7 +53,7 @@ export async function sendPrivySignMessage(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     { retryCount: 0 },
-  )) as any;
+  )) as Hex;
   return result;
 }
 
@@ -68,6 +68,6 @@ export async function sendPrivySignTypedData(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     { retryCount: 0 },
-  )) as any;
+  )) as Hex;
   return result;
 }

--- a/packages/agw-client/src/actions/sendPrivyTransaction.ts
+++ b/packages/agw-client/src/actions/sendPrivyTransaction.ts
@@ -1,7 +1,10 @@
 import {
   type Account,
   type Client,
+  type Hex,
   type SendTransactionRequest,
+  type SignMessageParameters,
+  type SignTypedDataParameters,
   toHex,
   type Transport,
 } from 'viem';
@@ -32,6 +35,36 @@ export async function sendPrivyTransaction<
     {
       method: 'privy_sendSmartWalletTx',
       params: [replaceBigInts(parameters, toHex)],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    { retryCount: 0 },
+  )) as any;
+  return result;
+}
+
+export async function sendPrivySignMessage(
+  client: Client<Transport, ChainEIP712, Account>,
+  parameters: Omit<SignMessageParameters, 'account'>,
+): Promise<Hex> {
+  const result = (await client.request(
+    {
+      method: 'privy_signSmartWalletMessage',
+      params: [parameters.message],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    { retryCount: 0 },
+  )) as any;
+  return result;
+}
+
+export async function sendPrivySignTypedData(
+  client: Client<Transport, ChainEIP712, Account>,
+  parameters: Omit<SignTypedDataParameters, 'account' | 'privateKey'>,
+): Promise<Hex> {
+  const result = (await client.request(
+    {
+      method: 'privy_signSmartWalletTypedData',
+      params: [client.account.address, parameters],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     { retryCount: 0 },

--- a/packages/agw-client/src/actions/signMessage.ts
+++ b/packages/agw-client/src/actions/signMessage.ts
@@ -22,7 +22,9 @@ export async function signMessage(
   if (typeof parameters.message === 'object')
     parameters.message = parameters.message.raw.toString();
 
-  if (isPrivyCrossApp) return await sendPrivySignMessage(client, parameters);
+  if (isPrivyCrossApp) {
+    return await sendPrivySignMessage(client, parameters);
+  }
 
   return await getAgwTypedSignature({
     client,

--- a/packages/agw-client/src/actions/signMessage.ts
+++ b/packages/agw-client/src/actions/signMessage.ts
@@ -10,12 +10,20 @@ import {
 import type { ChainEIP712 } from 'viem/chains';
 
 import { getAgwTypedSignature } from '../getAgwTypedSignature.js';
+import { sendPrivySignMessage } from './sendPrivyTransaction.js';
 
 export async function signMessage(
   client: Client<Transport, ChainEIP712, Account>,
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
   parameters: Omit<SignMessageParameters, 'account'>,
+  isPrivyCrossApp = false,
 ): Promise<Hex> {
+  // We handle {message: {raw}} here because the message is expected to be a string
+  if (typeof parameters.message === 'object')
+    parameters.message = parameters.message.raw.toString();
+
+  if (isPrivyCrossApp) return await sendPrivySignMessage(client, parameters);
+
   return await getAgwTypedSignature({
     client,
     signer: signerClient,

--- a/packages/agw-client/src/actions/signTypedData.ts
+++ b/packages/agw-client/src/actions/signTypedData.ts
@@ -15,12 +15,16 @@ import type { ChainEIP712 } from 'viem/chains';
 import { VALIDATOR_ADDRESS } from '../constants.js';
 import { isEIP712Transaction } from '../eip712.js';
 import { getAgwTypedSignature } from '../getAgwTypedSignature.js';
+import { sendPrivySignTypedData } from './sendPrivyTransaction.js';
 
 export async function signTypedData(
   client: Client<Transport, ChainEIP712, Account>,
   signerClient: WalletClient<Transport, ChainEIP712, Account>,
   parameters: Omit<SignTypedDataParameters, 'account' | 'privateKey'>,
+  isPrivyCrossApp = false,
 ): Promise<Hex> {
+  if (isPrivyCrossApp) return await sendPrivySignTypedData(client, parameters);
+
   // if the typed data is already a zkSync EIP712 transaction, don't try to transform it
   // to an AGW typed signature, just pass it through to the signer.
   if (

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -110,7 +110,7 @@ export function globalWalletActions<
       ),
 
     signMessage: (args: Omit<SignMessageParameters, 'account'>) =>
-      signMessage(client, signerClient, args),
+      signMessage(client, signerClient, args, isPrivyCrossApp),
     signTransaction: (args) =>
       signTransaction(
         client,
@@ -119,7 +119,7 @@ export function globalWalletActions<
       ),
     signTypedData: (
       args: Omit<SignTypedDataParameters, 'account' | 'privateKey'>,
-    ) => signTypedData(client, signerClient, args),
+    ) => signTypedData(client, signerClient, args, isPrivyCrossApp),
     deployContract: (args) =>
       deployContract(client, signerClient, publicClient, args, isPrivyCrossApp),
     writeContract: (args) =>

--- a/packages/agw-client/test/src/actions/signMessage.test.ts
+++ b/packages/agw-client/test/src/actions/signMessage.test.ts
@@ -12,7 +12,7 @@ import {
 } from 'viem';
 import { toAccount } from 'viem/accounts';
 import { ChainEIP712 } from 'viem/zksync';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import AccountFactoryAbi from '../../../src/abis/AccountFactory.js';
 import { signMessage } from '../../../src/actions/signMessage.js';

--- a/packages/agw-react/package.json
+++ b/packages/agw-react/package.json
@@ -56,7 +56,7 @@
   ],
   "peerDependencies": {
     "@abstract-foundation/agw-client": "^workspace:*",
-    "@privy-io/cross-app-connect": "0.0.8-beta-20241111164156",
+    "@privy-io/cross-app-connect": "^0.0.8",
     "@privy-io/react-auth": "^1.92.2",
     "@tanstack/react-query": "^5",
     "react": ">=18",
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@abstract-foundation/agw-client": "workspace:*",
-    "@privy-io/cross-app-connect": "0.0.8-beta-20241111164156",
+    "@privy-io/cross-app-connect": "^0.0.8",
     "@privy-io/react-auth": "^1.92.2",
     "@rainbow-me/rainbowkit": "^2.1.6",
     "@tanstack/query-core": "^5.56.2",

--- a/packages/agw-react/package.json
+++ b/packages/agw-react/package.json
@@ -56,7 +56,7 @@
   ],
   "peerDependencies": {
     "@abstract-foundation/agw-client": "^workspace:*",
-    "@privy-io/cross-app-connect": "^0.0.6",
+    "@privy-io/cross-app-connect": "0.0.8-beta-20241111164156",
     "@privy-io/react-auth": "^1.92.2",
     "@tanstack/react-query": "^5",
     "react": ">=18",
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@abstract-foundation/agw-client": "workspace:*",
-    "@privy-io/cross-app-connect": "^0.0.7",
+    "@privy-io/cross-app-connect": "0.0.8-beta-20241111164156",
     "@privy-io/react-auth": "^1.92.2",
     "@rainbow-me/rainbowkit": "^2.1.6",
     "@tanstack/query-core": "^5.56.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: workspace:*
         version: link:../agw-client
       '@privy-io/cross-app-connect':
-        specifier: 0.0.8-beta-20241111164156
-        version: 0.0.8-beta-20241111164156(exrm5rvwyxsv5ods2xefnc55be)
+        specifier: ^0.0.8
+        version: 0.0.8(exrm5rvwyxsv5ods2xefnc55be)
       '@privy-io/react-auth':
         specifier: ^1.92.2
         version: 1.92.2(@solana/web3.js@1.95.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.9)(bs58@5.0.0)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -1500,8 +1500,8 @@ packages:
     resolution: {integrity: sha512-DjfECWu/YhI5WGnUtdzvQnnj7JVCtSh+hbgIX0zjybvjKGt7mI41cUSvHhgr613so7tupbklJeUSXqIsIt66tw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
 
-  '@privy-io/cross-app-connect@0.0.8-beta-20241111164156':
-    resolution: {integrity: sha512-HBmcqWd/BuCUx/DpDNQu+Tz2kQDI4wcfasKt+KDTDuDhvN5sFVAW1jweOqWoVPZGKBoH22BcD/1m5Sm70QHW4w==}
+  '@privy-io/cross-app-connect@0.0.8':
+    resolution: {integrity: sha512-47pHtMvIucAOey6daVJtduyDJzta9vZK/EdOTFOjpQ6ctN7HMtNHwi4iOQl8U7CWoAjxzzyzvWGJx/1Q31WQrQ==}
     peerDependencies:
       '@rainbow-me/rainbowkit': ^2.1.5
       '@wagmi/core': ^2.13.4
@@ -7670,7 +7670,7 @@ snapshots:
     dependencies:
       zod: 3.23.8
 
-  '@privy-io/cross-app-connect@0.0.8-beta-20241111164156(exrm5rvwyxsv5ods2xefnc55be)':
+  '@privy-io/cross-app-connect@0.0.8(exrm5rvwyxsv5ods2xefnc55be)':
     dependencies:
       '@noble/curves': 1.6.0
       '@noble/hashes': 1.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: workspace:*
         version: link:../agw-client
       '@privy-io/cross-app-connect':
-        specifier: ^0.0.7
-        version: 0.0.7(exrm5rvwyxsv5ods2xefnc55be)
+        specifier: 0.0.8-beta-20241111164156
+        version: 0.0.8-beta-20241111164156(exrm5rvwyxsv5ods2xefnc55be)
       '@privy-io/react-auth':
         specifier: ^1.92.2
         version: 1.92.2(@solana/web3.js@1.95.3(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.9)(bs58@5.0.0)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -1500,8 +1500,8 @@ packages:
     resolution: {integrity: sha512-DjfECWu/YhI5WGnUtdzvQnnj7JVCtSh+hbgIX0zjybvjKGt7mI41cUSvHhgr613so7tupbklJeUSXqIsIt66tw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
 
-  '@privy-io/cross-app-connect@0.0.7':
-    resolution: {integrity: sha512-cx9tQZqhAxTiRuN6HtxPbmFnJiIQ9KvMQP/PQ+Cfe/2rLTzjCe3ZqKfgvUkvB0226oYzcFOyIn5o/UoUcsvsRg==}
+  '@privy-io/cross-app-connect@0.0.8-beta-20241111164156':
+    resolution: {integrity: sha512-HBmcqWd/BuCUx/DpDNQu+Tz2kQDI4wcfasKt+KDTDuDhvN5sFVAW1jweOqWoVPZGKBoH22BcD/1m5Sm70QHW4w==}
     peerDependencies:
       '@rainbow-me/rainbowkit': ^2.1.5
       '@wagmi/core': ^2.13.4
@@ -7670,7 +7670,7 @@ snapshots:
     dependencies:
       zod: 3.23.8
 
-  '@privy-io/cross-app-connect@0.0.7(exrm5rvwyxsv5ods2xefnc55be)':
+  '@privy-io/cross-app-connect@0.0.8-beta-20241111164156(exrm5rvwyxsv5ods2xefnc55be)':
     dependencies:
       '@noble/curves': 1.6.0
       '@noble/hashes': 1.3.2


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `@privy-io/cross-app-connect` dependency version and enhancing the signing functions to support cross-app interactions with Privy, including new methods for signing messages and typed data.

### Detailed summary
- Updated `@privy-io/cross-app-connect` version from `0.0.6` to `0.0.8`.
- Modified `signMessage` and `signTypedData` functions to include `isPrivyCrossApp` parameter.
- Added `sendPrivySignMessage` and `sendPrivySignTypedData` functions for signing with Privy.
- Updated tests to validate new cross-app signing behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->