### PR TITLE
refactor valid chains to be part of agw-client; dedupe chain checking code

### DIFF
--- a/packages/agw-client/src/actions/signTransaction.ts
+++ b/packages/agw-client/src/actions/signTransaction.ts
@@ -8,7 +8,6 @@ import {
   type WalletClient,
 } from 'viem';
 import { getChainId, signTypedData } from 'viem/actions';
-import { abstractTestnet } from 'viem/chains';
 import { assertCurrentChain, getAction, parseAccount } from 'viem/utils';
 import {
   type ChainEIP712,
@@ -22,9 +21,8 @@ import {
   type AssertEip712RequestParameters,
 } from '../eip712.js';
 import { AccountNotFoundError } from '../errors/account.js';
+import { validChains } from '../exports/index.js';
 import { transformHexValues } from '../utils.js';
-
-const ALLOWED_CHAINS: number[] = [abstractTestnet.id];
 
 export async function signTransaction<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
@@ -67,7 +65,7 @@ export async function signTransaction<
     ...(transaction as AssertEip712RequestParameters),
   });
 
-  if (!chain || !ALLOWED_CHAINS.includes(chain.id)) {
+  if (!chain || validChains[chain.id] === undefined) {
     throw new BaseError('Invalid chain specified');
   }
 

--- a/packages/agw-client/src/exports/index.ts
+++ b/packages/agw-client/src/exports/index.ts
@@ -4,4 +4,7 @@ export {
 } from '../abstractClient.js';
 export { deployAccount } from '../actions/deployAccount.js';
 export { transformEIP1193Provider } from '../transformEIP1193Provider.js';
-export { getSmartAccountAddressFromInitialSigner } from '../utils.js';
+export {
+  getSmartAccountAddressFromInitialSigner,
+  VALID_CHAINS as validChains,
+} from '../utils.js';

--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -1,5 +1,6 @@
 import {
   type Address,
+  type Chain,
   encodeFunctionData,
   fromHex,
   type Hex,
@@ -9,11 +10,17 @@ import {
   toBytes,
   type Transport,
 } from 'viem';
+import { abstractTestnet } from 'viem/chains';
 import { type ChainEIP712 } from 'viem/zksync';
 
 import AccountFactoryAbi from './abis/AccountFactory.js';
 import { SMART_ACCOUNT_FACTORY_ADDRESS } from './constants.js';
 import { type Call } from './types/call.js';
+
+// TODO: support Abstract mainnet
+export const VALID_CHAINS: Record<number, Chain> = {
+  [abstractTestnet.id]: abstractTestnet,
+};
 
 export function convertBigIntToString(value: any): any {
   if (typeof value === 'bigint') {

--- a/packages/agw-react/src/abstractWalletConnector.ts
+++ b/packages/agw-react/src/abstractWalletConnector.ts
@@ -1,9 +1,11 @@
-import { transformEIP1193Provider } from '@abstract-foundation/agw-client';
+import {
+  transformEIP1193Provider,
+  validChains,
+} from '@abstract-foundation/agw-client';
 import { toPrivyWalletConnector } from '@privy-io/cross-app-connect';
 import type { WalletDetailsParams } from '@rainbow-me/rainbowkit';
 import { type CreateConnectorFn } from '@wagmi/core';
 import {
-  type Chain,
   type EIP1193EventMap,
   type EIP1193RequestFn,
   type EIP1474Methods,
@@ -11,11 +13,6 @@ import {
 import { abstractTestnet } from 'viem/chains';
 
 import { AGW_APP_ID, ICON_URL } from './constants.js';
-
-// TODO: support Abstract mainnet
-export const VALID_CHAINS: Record<number, Chain> = {
-  [abstractTestnet.id]: abstractTestnet,
-};
 
 /**
  * Create a wagmi connector for the Abstract Global Wallet.
@@ -65,7 +62,7 @@ function abstractWalletConnector(
       parameters?: { chainId?: number | undefined } | undefined,
     ) => {
       const chainId = parameters?.chainId ?? abstractTestnet.id;
-      const chain = VALID_CHAINS[chainId];
+      const chain = validChains[chainId];
       if (!chain) {
         throw new Error('Unsupported chain');
       }

--- a/packages/agw-react/src/abstractWalletThirdweb.ts
+++ b/packages/agw-react/src/abstractWalletThirdweb.ts
@@ -1,11 +1,9 @@
+import { validChains } from '@abstract-foundation/agw-client';
 import { createEmitter } from '@wagmi/core/internal';
 import { EIP1193, type Wallet } from 'thirdweb/wallets';
 import type { Chain } from 'viem/chains';
 
-import {
-  abstractWalletConnector,
-  VALID_CHAINS,
-} from './abstractWalletConnector.js';
+import { abstractWalletConnector } from './abstractWalletConnector.js';
 
 /**
  * Create a thirdweb wallet for Abstract Global Wallet
@@ -24,7 +22,7 @@ import {
  */
 const abstractWallet = (): Wallet => {
   const connector = abstractWalletConnector()({
-    chains: Object.values(VALID_CHAINS) as [Chain, ...Chain[]],
+    chains: Object.values(validChains) as [Chain, ...Chain[]],
     emitter: createEmitter('xyz.abs'),
   });
   return EIP1193.fromProvider({


### PR DESCRIPTION

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the handling of valid blockchain networks in the `agw-client` and `agw-react` packages. It introduces a new export for `VALID_CHAINS` and updates references to ensure consistency across the codebase.

### Detailed summary
- Added `VALID_CHAINS` export in `packages/agw-client/src/utils.ts`.
- Updated `packages/agw-client/src/exports/index.ts` to export `VALID_CHAINS`.
- Changed references from `VALID_CHAINS` to `validChains` in `packages/agw-react/src/abstractWalletThirdweb.ts` and `packages/agw-react/src/abstractWalletConnector.ts`.
- Modified chain validation logic in `packages/agw-client/src/actions/signTransaction.ts` to use `validChains`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->