### PR TITLE
Bump @eslint/plugin-kit; CVE-2024-21539

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
+    "@eslint/plugin-kit": ">=0.2.3",
     "publint": "^0.2.12",
     "tsc-watch": "^6.2.0",
     "typescript-eslint": "^8.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.16.4
         version: 0.16.4
+      '@eslint/plugin-kit':
+        specifier: '>=0.2.3'
+        version: 0.2.3
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
@@ -1101,8 +1104,8 @@ packages:
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.2.0':
-    resolution: {integrity: sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==}
+  '@eslint/plugin-kit@0.2.3':
+    resolution: {integrity: sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ethereumjs/common@3.2.0':
@@ -7653,7 +7656,7 @@ snapshots:
 
   '@eslint/object-schema@2.1.4': {}
 
-  '@eslint/plugin-kit@0.2.0':
+  '@eslint/plugin-kit@0.2.3':
     dependencies:
       levn: 0.4.1
 
@@ -11204,7 +11207,7 @@ snapshots:
       '@eslint/core': 0.6.0
       '@eslint/eslintrc': 3.1.0
       '@eslint/js': 9.11.1
-      '@eslint/plugin-kit': 0.2.0
+      '@eslint/plugin-kit': 0.2.3
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.3.0
       '@nodelib/fs.walk': 1.2.8


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `@eslint/plugin-kit` package version from `0.2.0` to `0.2.3` in the `package.json` and `pnpm-lock.yaml` files, ensuring compatibility with the specified version range.

### Detailed summary
- Added `@eslint/plugin-kit` with version `>=0.2.3` in `package.json`.
- Updated `@eslint/plugin-kit` version from `0.2.0` to `0.2.3` in `pnpm-lock.yaml`.
- Updated integrity hash for `@eslint/plugin-kit@0.2.3` in `pnpm-lock.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->