### PR TITLE
Bump secp256k1-node: CVE-2024-48930

### DIFF
--- a/packages/agw-react/package.json
+++ b/packages/agw-react/package.json
@@ -68,6 +68,7 @@
     "@privy-io/react-auth": "^1.92.2",
     "@tanstack/react-query": "^5",
     "react": ">=18",
+    "secp256k1": ">=5.0.1",
     "typescript": ">=5.0.4",
     "thirdweb": "^5.68.0",
     "viem": "^2.21.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5
         version: 5.56.2(react@18.3.1)
+      secp256k1:
+        specifier: '>=5.0.1'
+        version: 5.0.1
       typescript:
         specifier: '>=5.0.4'
         version: 5.6.2
@@ -3318,9 +3321,6 @@ packages:
   elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
 
-  elliptic@6.5.7:
-    resolution: {integrity: sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==}
-
   elliptic@6.6.0:
     resolution: {integrity: sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==}
 
@@ -5375,9 +5375,9 @@ packages:
   scrypt-js@3.0.1:
     resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
 
-  secp256k1@5.0.0:
-    resolution: {integrity: sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==}
-    engines: {node: '>=14.0.0'}
+  secp256k1@5.0.1:
+    resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
+    engines: {node: '>=18.0.0'}
 
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
@@ -10263,7 +10263,7 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
-      elliptic: 6.5.7
+      elliptic: 6.6.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
     transitivePeerDependencies:
@@ -11006,23 +11006,13 @@ snapshots:
     dependencies:
       '@types/secp256k1': 4.0.6
       futoin-hkdf: 1.5.3
-      secp256k1: 5.0.0
+      secp256k1: 5.0.1
 
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.28: {}
 
   elliptic@6.5.4:
-    dependencies:
-      bn.js: 4.12.0
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
-
-  elliptic@6.5.7:
     dependencies:
       bn.js: 4.12.0
       brorand: 1.1.0
@@ -13388,9 +13378,9 @@ snapshots:
 
   scrypt-js@3.0.1: {}
 
-  secp256k1@5.0.0:
+  secp256k1@5.0.1:
     dependencies:
-      elliptic: 6.5.7
+      elliptic: 6.6.0
       node-addon-api: 5.1.0
       node-gyp-build: 4.8.2
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `secp256k1` package version and making related adjustments in the `package.json` and `pnpm-lock.yaml` files, along with updating the `elliptic` package version.

### Detailed summary
- Added `secp256k1` dependency with version `>=5.0.1` in `package.json`.
- Updated `secp256k1` version from `5.0.0` to `5.0.1` in `pnpm-lock.yaml`.
- Updated `elliptic` version from `6.5.7` to `6.6.0` in `pnpm-lock.yaml`.
- Changed `node` engine requirement for `secp256k1` from `>=14.0.0` to `>=18.0.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->