### PR TITLE
chore: bump agw-react to 0.0.1-beta-20

### DIFF
--- a/packages/agw-react/package.json
+++ b/packages/agw-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abstract-foundation/agw-react",
   "description": "Abstract Global Wallet React Components",
-  "version": "0.0.1-beta.19",
+  "version": "0.0.1-beta.20",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@abstract-foundation/agw-react` package in its `package.json` file from `0.0.1-beta.19` to `0.0.1-beta.20`.

### Detailed summary
- Updated the `version` of `@abstract-foundation/agw-react` from `0.0.1-beta.19` to `0.0.1-beta.20`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->