### PR TITLE
Ensure cross app is set to true for use client hook

### DIFF
--- a/packages/agw-react/src/hooks/useAbstractClient.ts
+++ b/packages/agw-react/src/hooks/useAbstractClient.ts
@@ -20,6 +20,7 @@ export const useAbstractClient = () => {
         signer: signer.account,
         chain,
         transport: custom(signer.transport),
+        isPrivyCrossApp: true,
       });
 
       return client;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new property `isPrivyCrossApp` set to `true` in the configuration of a client object, likely indicating a specific application behavior or feature related to cross-application functionality.

### Detailed summary
- Added `isPrivyCrossApp: true` to the client configuration in the `useAbstractClient` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->