### PR TITLE
feat: Add EIP-5792 support to 1193 provider

### DIFF
--- a/packages/agw-client/src/eip5792.ts
+++ b/packages/agw-client/src/eip5792.ts
@@ -12,17 +12,16 @@ interface ChainCapabilities {
 
 type WalletCapabilities = Record<`0x${string}`, ChainCapabilities>;
 
-interface SendCallData {
-  to: Address;
-  value: Hex;
-  data: Hex;
-  chainId: Hex;
-}
-
-export interface SendCallsParameters {
-  version: '1.0';
+export interface SendCallsParams {
+  version: string;
   from: Address;
-  calls: SendCallData[];
+  calls: {
+    to?: Address | undefined;
+    data?: Hex | undefined;
+    value?: Hex | undefined;
+    chainId?: Hex | undefined;
+  }[];
+  capabilities?: WalletCapabilities | undefined;
 }
 
 export const agwCapablities: WalletCapabilities = {

--- a/packages/agw-client/src/eip5792.ts
+++ b/packages/agw-client/src/eip5792.ts
@@ -1,0 +1,39 @@
+import type { Address, Hex } from 'viem';
+
+interface Capability {
+  supported: boolean;
+}
+
+interface ChainCapabilities {
+  paymasterService?: Capability;
+  sessionKeys?: Capability;
+  atomicBatch?: Capability;
+}
+
+type WalletCapabilities = Record<`0x${string}`, ChainCapabilities>;
+
+interface SendCallData {
+  to: Address;
+  value: Hex;
+  data: Hex;
+  chainId: Hex;
+}
+
+export interface SendCallsParameters {
+  version: '1.0';
+  from: Address;
+  calls: SendCallData[];
+}
+
+export const agwCapablities: WalletCapabilities = {
+  '0xab5': {
+    atomicBatch: {
+      supported: true,
+    },
+  },
+  '0x2b74': {
+    atomicBatch: {
+      supported: true,
+    },
+  },
+};

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -15,7 +15,7 @@ import {
 import { toAccount } from 'viem/accounts';
 
 import { createAbstractClient } from './abstractClient.js';
-import { agwCapablities, type SendCallsParameters } from './eip5792.js';
+import { agwCapablities, type SendCallsParams } from './eip5792.js';
 import { getSmartAccountAddressFromInitialSigner } from './utils.js';
 
 interface TransformEIP1193ProviderOptions {
@@ -199,7 +199,7 @@ export function transformEIP1193Provider(
         if (!account) {
           throw new Error('Account not found');
         }
-        const sendCallsParams = params[0] as SendCallsParameters;
+        const sendCallsParams = params[0] as SendCallsParams;
 
         if (sendCallsParams.from === account) {
           return await provider.request(e);
@@ -215,9 +215,9 @@ export function transformEIP1193Provider(
         return await abstractClient.sendTransactionBatch({
           calls: sendCallsParams.calls.map((call) => ({
             to: call.to,
-            value: hexToBigInt(call.value),
+            value: call.value ? hexToBigInt(call.value) : undefined,
             data: call.data,
-            chainId: hexToBigInt(call.chainId),
+            chainId: call.chainId ? hexToBigInt(call.chainId) : undefined,
           })),
         });
       }

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -8,12 +8,14 @@ import {
   type EIP1193Provider,
   type EIP1193RequestFn,
   type EIP1474Methods,
+  hexToBigInt,
   toHex,
   type Transport,
 } from 'viem';
 import { toAccount } from 'viem/accounts';
 
 import { createAbstractClient } from './abstractClient.js';
+import { agwCapablities, type SendCallsParameters } from './eip5792.js';
 import { getSmartAccountAddressFromInitialSigner } from './utils.js';
 
 interface TransformEIP1193ProviderOptions {
@@ -191,6 +193,53 @@ export function transformEIP1193Provider(
           return await abstractClient.sendTransaction(transaction);
         }
         throw new Error('Should not have reached this point');
+      }
+      case 'wallet_sendCalls': {
+        const account = await getAgwSigner(provider);
+        if (!account) {
+          throw new Error('Account not found');
+        }
+        const sendCallsParams = params[0] as SendCallsParameters;
+
+        if (sendCallsParams.from === account) {
+          return await provider.request(e);
+        }
+
+        const abstractClient = await getAgwClient(
+          account,
+          chain,
+          transport,
+          isPrivyCrossApp,
+        );
+
+        return await abstractClient.sendTransactionBatch({
+          calls: sendCallsParams.calls.map((call) => ({
+            to: call.to,
+            value: hexToBigInt(call.value),
+            data: call.data,
+            chainId: hexToBigInt(call.chainId),
+          })),
+        });
+      }
+      case 'wallet_getCallsStatus': {
+        return await provider.request({
+          method: 'eth_getTransactionReceipt',
+          params,
+        });
+      }
+      case 'wallet_showCallsStatus': {
+        // not implemented
+        return undefined;
+      }
+      case 'wallet_getCapabilities': {
+        const account = await getAgwSigner(provider);
+        if (!account) {
+          throw new Error('Account not found');
+        }
+        if (params[0] === account) {
+          return await provider.request(e);
+        }
+        return agwCapablities;
       }
       default: {
         return await provider.request(e);

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -427,6 +427,22 @@ describe('transformEIP1193Provider', () => {
 
       expect(result).toBe(agwCapablities);
     });
+    it('should pass through wallet_getCapabilities to base client when called with external signer', async () => {
+      const mockAccounts: Address[] = [
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      ];
+
+      (mockProvider.request as Mock).mockResolvedValueOnce(mockAccounts);
+      const result = await transformedProvider.request({
+        method: 'wallet_getCapabilities',
+        params: [mockAccounts[0] as any],
+      });
+
+      expect(mockProvider.request).toHaveBeenCalledWith({
+        method: 'wallet_getCapabilities',
+        params: [mockAccounts[0] as any],
+      });
+    });
     it('should throw an error on wallet_getCapabilities if there are not accounts', async () => {
       const mockAccounts = [];
       const mockSmartAccount = '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199';
@@ -489,6 +505,55 @@ describe('transformEIP1193Provider', () => {
       });
 
       expect(result).toBe(mockSignedTransaction);
+    });
+    it('should pass wallet_sendCalls through to base client when called with external signer', async () => {
+      const mockAccounts: Address[] = [
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+      ];
+
+      const mockSignedTransaction = '0xsigned';
+
+      const calls: SendCallsParams['calls'] = [
+        {
+          to: privateKeyToAccount(generatePrivateKey()).address,
+          data: '0x12345678',
+        },
+        {
+          to: privateKeyToAccount(generatePrivateKey()).address,
+          value: toHex(parseEther('0.01')),
+        },
+      ];
+
+      (mockProvider.request as Mock).mockResolvedValueOnce(mockAccounts);
+      vi.spyOn(
+        abstractClientModule,
+        'createAbstractClient',
+      ).mockResolvedValueOnce({
+        sendTransactionBatch: vi
+          .fn()
+          .mockResolvedValueOnce(mockSignedTransaction),
+      } as any);
+      const result = await transformedProvider.request({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            version: '1.0',
+            from: mockAccounts[0],
+            calls,
+          },
+        ],
+      });
+
+      expect(mockProvider.request).toHaveBeenCalledWith({
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            version: '1.0',
+            from: mockAccounts[0],
+            calls,
+          },
+        ],
+      });
     });
     it('should throw an error on wallet_sendCalls if there are not accounts', async () => {
       const mockAccounts = [];

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -427,6 +427,28 @@ describe('transformEIP1193Provider', () => {
 
       expect(result).toBe(agwCapablities);
     });
+    it('should throw an error on wallet_getCapabilities if there are not accounts', async () => {
+      const mockAccounts = [];
+      const mockSmartAccount = '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199';
+      const calls: SendCallsParams['calls'] = [
+        {
+          to: privateKeyToAccount(generatePrivateKey()).address,
+          data: '0x12345678',
+        },
+        {
+          to: privateKeyToAccount(generatePrivateKey()).address,
+          value: toHex(parseEther('0.01')),
+        },
+      ];
+      (mockProvider.request as Mock).mockResolvedValueOnce(mockAccounts);
+
+      await expect(
+        transformedProvider.request({
+          method: 'wallet_getCapabilities',
+          params: [mockSmartAccount as any],
+        }),
+      ).rejects.toThrowError('Account not found');
+    });
     it('should call abstract client sendBatchTransactions with wallet_sendCalls', async () => {
       const mockAccounts: Address[] = [
         '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
@@ -467,6 +489,34 @@ describe('transformEIP1193Provider', () => {
       });
 
       expect(result).toBe(mockSignedTransaction);
+    });
+    it('should throw an error on wallet_sendCalls if there are not accounts', async () => {
+      const mockAccounts = [];
+      const mockSmartAccount = '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199';
+      const calls: SendCallsParams['calls'] = [
+        {
+          to: privateKeyToAccount(generatePrivateKey()).address,
+          data: '0x12345678',
+        },
+        {
+          to: privateKeyToAccount(generatePrivateKey()).address,
+          value: toHex(parseEther('0.01')),
+        },
+      ];
+      (mockProvider.request as Mock).mockResolvedValueOnce(mockAccounts);
+
+      await expect(
+        transformedProvider.request({
+          method: 'wallet_sendCalls',
+          params: [
+            {
+              version: '1.0',
+              from: mockSmartAccount,
+              calls,
+            },
+          ],
+        }),
+      ).rejects.toThrowError('Account not found');
     });
     it('should pass transform wallet_getCallsStatus to eth_getTransactionReceipt', async () => {
       const mockTxHash = '0xtxhash';

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -15,7 +15,7 @@ import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import * as abstractClientModule from '../../src/abstractClient.js';
 import { sendTransactionBatch } from '../../src/actions/sendTransaction.js';
-import { agwCapablities } from '../../src/eip5792.js';
+import { agwCapablities, SendCallsParams } from '../../src/eip5792.js';
 import { transformEIP1193Provider } from '../../src/transformEIP1193Provider.js';
 import * as utilsModule from '../../src/utils.js';
 import { exampleTypedData } from '../fixtures.js';
@@ -435,7 +435,7 @@ describe('transformEIP1193Provider', () => {
 
       const mockSignedTransaction = '0xsigned';
 
-      const calls = [
+      const calls: SendCallsParams['calls'] = [
         {
           to: privateKeyToAccount(generatePrivateKey()).address,
           data: '0x12345678',
@@ -456,11 +456,17 @@ describe('transformEIP1193Provider', () => {
           .mockResolvedValueOnce(mockSignedTransaction),
       } as any);
       const result = await transformedProvider.request({
-        method: 'wallet_getCapabilities',
-        params: [mockSmartAccount as any],
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            version: '1.0',
+            from: mockSmartAccount,
+            calls,
+          },
+        ],
       });
 
-      expect(result).toBe(agwCapablities);
+      expect(result).toBe(mockSignedTransaction);
     });
   });
 });

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -2,7 +2,6 @@ import {
   Address,
   type EIP1193EventMap,
   type EIP1193Provider,
-  formatEther,
   hexToBytes,
   parseEther,
   serializeTypedData,
@@ -14,7 +13,6 @@ import { getGeneralPaymasterInput } from 'viem/zksync';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import * as abstractClientModule from '../../src/abstractClient.js';
-import { sendTransactionBatch } from '../../src/actions/sendTransaction.js';
 import { agwCapablities, SendCallsParams } from '../../src/eip5792.js';
 import { transformEIP1193Provider } from '../../src/transformEIP1193Provider.js';
 import * as utilsModule from '../../src/utils.js';

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -468,5 +468,18 @@ describe('transformEIP1193Provider', () => {
 
       expect(result).toBe(mockSignedTransaction);
     });
+    it('should pass transform wallet_getCallsStatus to eth_getTransactionReceipt', async () => {
+      const mockTxHash = '0xtxhash';
+
+      await transformedProvider.request({
+        method: 'wallet_getCallsStatus',
+        params: [mockTxHash],
+      });
+
+      expect(mockProvider.request).toHaveBeenCalledWith({
+        method: 'eth_getTransactionReceipt',
+        params: [mockTxHash],
+      });
+    });
   });
 });


### PR DESCRIPTION
Resolves #117

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for new wallet methods (`wallet_sendCalls`, `wallet_getCapabilities`, and `wallet_getCallsStatus`) in the `transformEIP1193Provider`, enhances type definitions in `eip5792.ts`, and adds corresponding tests in `transformEIP1193Provider.test.ts`.

### Detailed summary
- Added `Capability`, `ChainCapabilities`, and `WalletCapabilities` interfaces in `eip5792.ts`.
- Defined `SendCallsParams` interface for structured call parameters.
- Implemented handling for `wallet_sendCalls`, `wallet_getCapabilities`, and `wallet_getCallsStatus` methods in `transformEIP1193Provider.ts`.
- Integrated `agwCapablities` into the capabilities response.
- Updated tests in `transformEIP1193Provider.test.ts` to cover new wallet methods and scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->