### PR TITLE
Update typed signature type names

### DIFF
--- a/packages/agw-client/src/getAgwTypedSignature.ts
+++ b/packages/agw-client/src/getAgwTypedSignature.ts
@@ -50,12 +50,12 @@ export async function getAgwTypedSignature(
         { name: 'chainId', type: 'uint256' },
         { name: 'verifyingContract', type: 'address' },
       ],
-      ClaveMessage: [{ name: 'signedHash', type: 'bytes32' }],
+      AGWMessage: [{ name: 'signedHash', type: 'bytes32' }],
     },
     message: {
       signedHash: messageHash,
     },
-    primaryType: 'ClaveMessage',
+    primaryType: 'AGWMessage',
   });
 
   const signature = encodeAbiParameters(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the message structure in the `getAgwTypedSignature.ts` file, changing references from `ClaveMessage` to `AGWMessage`. It modifies the `primaryType` and the message format accordingly.

### Detailed summary
- Changed the type from `ClaveMessage` to `AGWMessage`.
- Updated the `primaryType` from `ClaveMessage` to `AGWMessage`.
- Adjusted the message object to maintain the new naming convention.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->