### PR TITLE
fix: removes duplicate method call

### DIFF
--- a/packages/agw-client/test/src/actions/sendTransaction/sendTransactionInternal.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransaction/sendTransactionInternal.test.ts
@@ -144,7 +144,7 @@ describe('sendTransactionInternal', () => {
 
       expect(transactionHash).toBe(MOCK_TRANSACTION_HASH);
 
-      expect(signTransaction).to.toHaveBeenCalledWith(
+      expect(signTransaction).toHaveBeenCalledWith(
         baseClient,
         signerClient,
         expect.objectContaining({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting a test expectation in the `sendTransactionInternal.test.ts` file. It removes an unnecessary extra `.to` in the `expect` statement for `signTransaction`.

### Detailed summary
- Fixed the `expect(signTransaction).to.toHaveBeenCalledWith` to `expect(signTransaction).toHaveBeenCalledWith` by removing the extra `.to`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->