### PR TITLE
fix: multi chain connector

### DIFF
--- a/.changeset/nice-plums-thank.md
+++ b/.changeset/nice-plums-thank.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Override transport when provider chain is not a supported chain

--- a/packages/agw-react/src/abstractWallet.ts
+++ b/packages/agw-react/src/abstractWallet.ts
@@ -26,7 +26,10 @@ const abstractWallet = (): Wallet => {
     iconBackground: '#ffffff',
     installed: true,
     shortName: 'Abstract',
-    createConnector: (rkDetails) => abstractWalletConnector(rkDetails),
+    createConnector: (rkDetails) =>
+      abstractWalletConnector({
+        rkDetails,
+      }),
   };
 };
 

--- a/packages/agw-react/src/abstractWalletConnector.ts
+++ b/packages/agw-react/src/abstractWalletConnector.ts
@@ -3,16 +3,25 @@ import {
   validChains,
 } from '@abstract-foundation/agw-client';
 import { toPrivyWalletConnector } from '@privy-io/cross-app-connect/rainbow-kit';
-import type { WalletDetailsParams } from '@rainbow-me/rainbowkit';
+import type { WalletDetailsParams } from '@rainbow-me/rainbowkit/dist/wallets/Wallet.js';
 import { type CreateConnectorFn } from '@wagmi/core';
 import {
   type EIP1193EventMap,
   type EIP1193RequestFn,
   type EIP1474Methods,
+  http,
+  type Transport,
 } from 'viem';
 import { abstractTestnet } from 'viem/chains';
 
 import { AGW_APP_ID, ICON_URL } from './constants.js';
+
+interface AbstractWalletConnectorOptions {
+  /** RainbowKit connector details */
+  rkDetails: WalletDetailsParams;
+  /** Override transports for chains */
+  overrideTransports: Record<number, Transport>;
+}
 
 /**
  * Create a wagmi connector for the Abstract Global Wallet.
@@ -35,8 +44,7 @@ import { AGW_APP_ID, ICON_URL } from './constants.js';
  * });
  */
 function abstractWalletConnector(
-  rkDetails?: WalletDetailsParams,
-  testnet = false,
+  options: Partial<AbstractWalletConnectorOptions> = {},
 ): CreateConnectorFn<
   {
     on: <event extends keyof EIP1193EventMap>(
@@ -52,15 +60,18 @@ function abstractWalletConnector(
   Record<string, unknown>,
   Record<string, unknown>
 > {
+  const { rkDetails, overrideTransports } = options;
+
   return (params) => {
-    const defaultChain = testnet ? abstractTestnet : abstractTestnet; // TODO: add mainnet chain
     const chains = [...params.chains];
     const chainIndex = chains.findIndex(
-      (chain) => chain.id === defaultChain.id,
-    );
+      (chain) => chain.id === abstractTestnet.id,
+    ); // TODO: add mainnet
     const hasChain = chainIndex !== -1;
+    let defaultChain = params.chains[0];
     if (hasChain) {
-      chains.splice(chainIndex, 1);
+      const removedChains = chains.splice(chainIndex, 1);
+      defaultChain = removedChains[0] ?? defaultChain;
     }
 
     const connector = toPrivyWalletConnector({
@@ -80,11 +91,25 @@ function abstractWalletConnector(
       if (!chain) {
         throw new Error('Unsupported chain');
       }
-      const provider = await connector.getProvider(parameters);
+      const provider = await connector.getProvider({
+        chainId,
+      });
+
+      const providerChainId = await provider.request({
+        method: 'eth_chainId',
+      });
+
+      let transport: Transport | undefined;
+      if (validChains[Number(providerChainId)] === undefined) {
+        // Transport is not overridden but provider is not on a supported chain,
+        // use default http transport
+        transport = overrideTransports?.[chainId] ?? http();
+      }
 
       return transformEIP1193Provider({
         provider,
         chain,
+        transport,
         isPrivyCrossApp: true,
       });
     };


### PR DESCRIPTION
## Summary
- For apps with multiple chains, some of which are not Abstract:
- When using multiple chains with wagmi, ensure that the provider passed to `transformEIP1193Provider` is pointing to the correct chain. Calls `eth_chainId` for the provider and overrides if the chain is not supported.
Add optional `overrideTransports` to connector setup

## Commits
- **fix: switch abstract to first chain in privy wallet connector when using cross connect**
- **override transport for transformEIP1193Provider if provider chain is not supported**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `abstractWalletConnector` functionality by allowing the overriding of transport options when the provider chain is not supported. It also refines how chains are handled and improves type definitions.

### Detailed summary
- Added support for overriding transports in `AbstractWalletConnectorOptions`.
- Modified `abstractWalletConnector` to accept options instead of just `rkDetails`.
- Implemented logic to set a default chain based on the provided chains.
- Updated provider retrieval to use the default chain and handle unsupported chains.
- Improved type imports for clarity and specificity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->