### PR TITLE
fix: correct spelling of 'agwCapabilities' in code and tests

### DIFF
--- a/packages/agw-client/src/eip5792.ts
+++ b/packages/agw-client/src/eip5792.ts
@@ -24,7 +24,7 @@ export interface SendCallsParams {
   capabilities?: WalletCapabilities | undefined;
 }
 
-export const agwCapablities: WalletCapabilities = {
+export const agwCapabilities: WalletCapabilities = {
   '0xab5': {
     atomicBatch: {
       supported: true,

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -15,7 +15,7 @@ import {
 import { toAccount } from 'viem/accounts';
 
 import { createAbstractClient } from './abstractClient.js';
-import { agwCapablities, type SendCallsParams } from './eip5792.js';
+import { agwCapabilities, type SendCallsParams } from './eip5792.js';
 import { getSmartAccountAddressFromInitialSigner } from './utils.js';
 
 interface TransformEIP1193ProviderOptions {
@@ -239,7 +239,7 @@ export function transformEIP1193Provider(
         if (params[0] === account) {
           return await provider.request(e);
         }
-        return agwCapablities;
+        return agwCapabilities;
       }
       default: {
         return await provider.request(e);

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -13,7 +13,7 @@ import { getGeneralPaymasterInput } from 'viem/zksync';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import * as abstractClientModule from '../../src/abstractClient.js';
-import { agwCapablities, SendCallsParams } from '../../src/eip5792.js';
+import { agwCapabilities, SendCallsParams } from '../../src/eip5792.js';
 import { transformEIP1193Provider } from '../../src/transformEIP1193Provider.js';
 import * as utilsModule from '../../src/utils.js';
 import { exampleTypedData } from '../fixtures.js';
@@ -423,7 +423,7 @@ describe('transformEIP1193Provider', () => {
         params: [mockSmartAccount as any],
       });
 
-      expect(result).toBe(agwCapablities);
+      expect(result).toBe(agwCapabilities);
     });
     it('should pass through wallet_getCapabilities to base client when called with external signer', async () => {
       const mockAccounts: Address[] = [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting a typo in the variable name from `agwCapablities` to `agwCapabilities` across multiple files to ensure consistency and prevent potential errors.

### Detailed summary
- Renamed `agwCapablities` to `agwCapabilities` in `eip5792.ts`.
- Updated import statements in `transformEIP1193Provider.ts` to reflect the new variable name.
- Changed the return statement in `transformEIP1193Provider` to use `agwCapabilities`.
- Adjusted the test file `transformEIP1193Provider.test.ts` to use the corrected variable name in imports and assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->