### PR TITLE
fix: add getChainId to abstract wallet client

### DIFF
--- a/.changeset/wise-waves-attend.md
+++ b/.changeset/wise-waves-attend.md
@@ -1,0 +1,6 @@
+---
+'@abstract-foundation/agw-client': patch
+'@abstract-foundation/agw-react': patch
+---
+
+Add getChainId to abstract wallet client

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -4,6 +4,7 @@ import {
   type Address,
   type Chain,
   type Client,
+  type GetChainIdReturnType,
   type PrepareTransactionRequestReturnType,
   type PublicClient,
   type SendTransactionRequest,
@@ -17,6 +18,7 @@ import {
   type WalletClient,
   type WriteContractParameters,
 } from 'viem';
+import { getChainId } from 'viem/actions';
 import {
   type ChainEIP712,
   type Eip712WalletActions,
@@ -60,6 +62,7 @@ export type AbstractWalletActions<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
   account extends Account | undefined = Account | undefined,
 > = Eip712WalletActions<chain, account> & {
+  getChainId: () => Promise<GetChainIdReturnType>;
   createSession: (
     args: CreateSessionParameters,
   ) => Promise<CreateSessionReturnType>;
@@ -155,6 +158,7 @@ export function globalWalletActions<
   return (
     client: Client<Transport, ChainEIP712, Account>,
   ): AbstractWalletActions<Chain, Account> => ({
+    getChainId: () => getChainId(client),
     createSession: (args) =>
       createSession(client, signerClient, publicClient, args, isPrivyCrossApp),
     revokeSessions: (args) =>


### PR DESCRIPTION
## Summary
Some libraries, notably ReservoirKit use the existence of getChainId to detect the presence of a wallet client. AbstractWalletActions extends `Eip712WalletActions`, NOT viem's `WalletActions`, and therefore does not have the `getChainId` method.

This PR adds this method, which should also resolve errors when attempting to use abstract wallet with reservoirkit.

Fixes https://github.com/reservoirprotocol/reservoir-kit/issues/827

## Commits
- **add getChainId to wallet actions**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a `getChainId` method to the `abstract wallet client`, enhancing its functionality by allowing it to retrieve the chain ID.

### Detailed summary
- Added `getChainId` method to the `AbstractWalletActions` type.
- Implemented `getChainId` in the `globalWalletActions` function to call the `getChainId` function from `viem/actions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->