### PR TITLE
fix: don't use ERC-6492 when AGW is deployed

### DIFF
--- a/.changeset/few-jars-brake.md
+++ b/.changeset/few-jars-brake.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Update message signing and typed signing to check codesize and only serialize as ERC-6942 signature if AGW is not deployed

--- a/packages/agw-client/src/getAgwTypedSignature.ts
+++ b/packages/agw-client/src/getAgwTypedSignature.ts
@@ -13,7 +13,7 @@ import {
   type Transport,
   zeroAddress,
 } from 'viem';
-import { signTypedData } from 'viem/actions';
+import { getCode, readContract, signTypedData } from 'viem/actions';
 import type { ChainEIP712 } from 'viem/chains';
 
 import AccountFactoryAbi from './abis/AccountFactory.js';
@@ -63,8 +63,24 @@ export async function getAgwTypedSignature(
     [rawSignature, EOA_VALIDATOR_ADDRESS],
   );
 
+  const code = await getCode(client, {
+    address: account.address,
+  });
+
+  // if the account is already deployed, we can use signature directly
+  // otherwise, we provide an ERC-6492 compatible signature
+  if (code !== undefined) {
+    return signature;
+  }
+
+  // Generate the ERC-6492 compatible signature
+  // https://eips.ethereum.org/EIPS/eip-6492
+
+  // 1. Generate the salt for account deployment
   const addressBytes = toBytes(signer.account.address);
   const salt = keccak256(addressBytes);
+
+  // 2. Generate the ERC-6492 compatible signature with deploy parameters
   return serializeErc6492Signature({
     address: SMART_ACCOUNT_FACTORY_ADDRESS,
     data: encodeFunctionData({

--- a/packages/agw-client/src/getAgwTypedSignature.ts
+++ b/packages/agw-client/src/getAgwTypedSignature.ts
@@ -13,7 +13,7 @@ import {
   type Transport,
   zeroAddress,
 } from 'viem';
-import { getCode, readContract, signTypedData } from 'viem/actions';
+import { getCode, signTypedData } from 'viem/actions';
 import type { ChainEIP712 } from 'viem/chains';
 
 import AccountFactoryAbi from './abis/AccountFactory.js';

--- a/packages/agw-client/test/src/actions/signTypedData.test.ts
+++ b/packages/agw-client/test/src/actions/signTypedData.test.ts
@@ -11,9 +11,16 @@ import {
   serializeErc6492Signature,
 } from 'viem';
 import { toAccount } from 'viem/accounts';
+import { getCode } from 'viem/actions';
 import { ChainEIP712 } from 'viem/zksync';
 import { describe, expect, it, vi } from 'vitest';
-
+vi.mock('viem/actions', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    getCode: vi.fn(),
+  };
+});
 import AccountFactoryAbi from '../../../src/abis/AccountFactory.js';
 import { signTypedData } from '../../../src/actions/signTypedData.js';
 import {
@@ -111,7 +118,23 @@ describe('signTypedData', async () => {
       ]),
     );
   });
-  it('should transform typed data to typed signature for smart account', async () => {
+  it('should transform typed data to typed signature for deployed smart account', async () => {
+    vi.mocked(getCode).mockResolvedValue('0xababab');
+    const expectedSignature = encodeAbiParameters(
+      parseAbiParameters(['bytes', 'address']),
+      [RAW_SIGNATURE, EOA_VALIDATOR_ADDRESS],
+    );
+
+    const signedMessage = await signTypedData(
+      baseClient,
+      signerClient,
+      exampleTypedData,
+    );
+
+    expect(signedMessage).toBe(expectedSignature);
+  });
+  it('should transform typed data to ERC-6492 typed signature for undeployed smart account', async () => {
+    vi.mocked(getCode).mockResolvedValue(undefined);
     const expectedSignature = serializeErc6492Signature({
       address: SMART_ACCOUNT_FACTORY_ADDRESS,
       signature: encodeAbiParameters(parseAbiParameters(['bytes', 'address']), [


### PR DESCRIPTION
- **fix: check codesize when signing message/typed message**
- **changeset**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the message signing process to include a check for the account's deployment status. It ensures that signatures are serialized as ERC-6492 only if the account is not deployed, enhancing the handling of typed signatures.

### Detailed summary
- Updated `getAgwTypedSignature` to check account deployment using `getCode`.
- Returned direct signature for deployed accounts; generated ERC-6492 signature for undeployed accounts.
- Modified tests for `signTypedData` and `signMessage` to reflect changes in signature handling based on deployment status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->