### PR TITLE
feat: add hook for creating session keys

### DIFF
--- a/.changeset/little-shirts-sit.md
+++ b/.changeset/little-shirts-sit.md
@@ -1,0 +1,6 @@
+---
+'@abstract-foundation/agw-client': patch
+'@abstract-foundation/agw-react': patch
+---
+
+Add hook for createSession

--- a/packages/agw-client/src/abis/SessionKeyValidator.ts
+++ b/packages/agw-client/src/abis/SessionKeyValidator.ts
@@ -1,4 +1,4 @@
-const SessionKeyValidatorAbi = [
+export const SessionKeyValidatorAbi = [
   {
     anonymous: false,
     inputs: [
@@ -1144,5 +1144,3 @@ const SessionKeyValidatorAbi = [
     type: 'function',
   },
 ] as const;
-
-export default SessionKeyValidatorAbi;

--- a/packages/agw-client/src/actions/createSession.ts
+++ b/packages/agw-client/src/actions/createSession.ts
@@ -12,7 +12,7 @@ import type { ChainEIP712 } from 'viem/chains';
 import { getAction } from 'viem/utils';
 
 import AGWAccountAbi from '../abis/AGWAccount.js';
-import SessionKeyValidatorAbi from '../abis/SessionKeyValidator.js';
+import { SessionKeyValidatorAbi } from '../abis/SessionKeyValidator.js';
 import { SESSION_KEY_VALIDATOR_ADDRESS } from '../constants.js';
 import { encodeSession, type SessionConfig } from '../sessions.js';
 import { isSmartAccountDeployed } from '../utils.js';

--- a/packages/agw-client/src/actions/revokeSessions.ts
+++ b/packages/agw-client/src/actions/revokeSessions.ts
@@ -8,7 +8,7 @@ import {
 } from 'viem';
 import type { ChainEIP712 } from 'viem/chains';
 
-import SessionKeyValidatorAbi from '../abis/SessionKeyValidator.js';
+import { SessionKeyValidatorAbi } from '../abis/SessionKeyValidator.js';
 import { SESSION_KEY_VALIDATOR_ADDRESS } from '../constants.js';
 import { getSessionHash, type SessionConfig } from '../sessions.js';
 import { writeContract } from './writeContract.js';

--- a/packages/agw-client/src/exports/sessions.ts
+++ b/packages/agw-client/src/exports/sessions.ts
@@ -1,3 +1,4 @@
+import { SessionKeyValidatorAbi } from '../abis/SessionKeyValidator.js';
 import {
   createSessionClient,
   type SessionClient,
@@ -30,6 +31,7 @@ export {
   LimitZero,
   type SessionClient,
   type SessionConfig,
+  SessionKeyValidatorAbi,
   type SessionState,
   type SessionStatus,
   toSessionClient,

--- a/packages/agw-client/src/sessions.ts
+++ b/packages/agw-client/src/sessions.ts
@@ -8,7 +8,7 @@ import {
   keccak256,
 } from 'viem';
 
-import SessionKeyValidatorAbi from './abis/SessionKeyValidator.js';
+import { SessionKeyValidatorAbi } from './abis/SessionKeyValidator.js';
 
 export enum LimitType {
   Unlimited = 0,

--- a/packages/agw-client/test/src/actions/revokeSessions.test.ts
+++ b/packages/agw-client/test/src/actions/revokeSessions.test.ts
@@ -28,7 +28,7 @@ vi.mock('viem/actions', () => ({
   readContract: vi.fn(),
 }));
 
-import SessionKeyValidatorAbi from '../../../src/abis/SessionKeyValidator.js';
+import { SessionKeyValidatorAbi } from '../../../src/abis/SessionKeyValidator.js';
 import { revokeSessions } from '../../../src/actions/revokeSessions.js';
 import { sendTransaction } from '../../../src/actions/sendTransaction.js';
 import {

--- a/packages/agw-react/src/exports/index.ts
+++ b/packages/agw-react/src/exports/index.ts
@@ -1,5 +1,6 @@
 export { AbstractWalletProvider } from '../agwProvider.js';
 export { useAbstractClient } from '../hooks/useAbstractClient.js';
+export { useCreateSession } from '../hooks/useCreateSession.js';
 export { useGlobalWalletSignerAccount } from '../hooks/useGlobalWalletSignerAccount.js';
 export { useGlobalWalletSignerClient } from '../hooks/useGlobalWalletSignerClient.js';
 export { useLoginWithAbstract } from '../hooks/useLoginWithAbstract.js';

--- a/packages/agw-react/src/hooks/useCreateSession.ts
+++ b/packages/agw-react/src/hooks/useCreateSession.ts
@@ -1,0 +1,43 @@
+import { sessionKeyValidatorAddress } from '@abstract-foundation/agw-client/constants';
+import {
+  type SessionConfig,
+  SessionKeyValidatorAbi,
+} from '@abstract-foundation/agw-client/sessions';
+import type { WriteContractParameters } from '@wagmi/core';
+import type { Address, Hex } from 'viem';
+import { useWriteContract } from 'wagmi';
+
+export type CreateSessionArgs = {
+  session: SessionConfig;
+  paymaster?: Address;
+  paymasterData?: Hex;
+} & Omit<WriteContractParameters, 'address' | 'abi' | 'functionName' | 'args'>;
+
+export const useCreateSession = () => {
+  const { writeContract, writeContractAsync, ...writeContractRest } =
+    useWriteContract();
+
+  return {
+    useCreateSession: (params: CreateSessionArgs) => {
+      const { session, ...rest } = params;
+      writeContract({
+        address: sessionKeyValidatorAddress,
+        abi: SessionKeyValidatorAbi,
+        functionName: 'createSession',
+        args: [session as never],
+        ...(rest as any),
+      });
+    },
+    useCreateSessionAsync: async (params: CreateSessionArgs) => {
+      const { session, ...rest } = params;
+      await writeContractAsync({
+        address: sessionKeyValidatorAddress,
+        abi: SessionKeyValidatorAbi,
+        functionName: 'createSession',
+        args: [session as any],
+        ...(rest as any),
+      });
+    },
+    ...writeContractRest,
+  };
+};


### PR DESCRIPTION
- **feat: create session hook**
- **changeset**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new hook for creating sessions and updates the import statements for `SessionKeyValidatorAbi` across various files, ensuring consistent usage. It also enhances the session management capabilities within the `agw-client` and `agw-react` packages.

### Detailed summary
- Added a new hook `useCreateSession` in `packages/agw-react/src/hooks/useCreateSession.ts`.
- Updated imports of `SessionKeyValidatorAbi` to named imports in multiple files.
- Exported `SessionKeyValidatorAbi` from `packages/agw-client/src/exports/sessions.ts`.
- Modified `createSession` functionality to utilize the new hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->