### PR TITLE
fix: allow passthrough of tx params on sendTransactionBatch

### DIFF
--- a/.changeset/pretty-tomatoes-grow.md
+++ b/.changeset/pretty-tomatoes-grow.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Allow passing through additional transaction parameters for sendTransactionBatch


### PR DESCRIPTION
Fixes #138 

- **pass through params for send transaction batch**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `sendTransactionBatch` function in the `agw-client` package to allow additional transaction parameters. It improves how transactions are handled and provides tests for the new functionality.

### Detailed summary
- Updated `sendTransactionBatch` to destructure `parameters` and use `rest` for additional args.
- Renamed `calls` to `batchCalls` for clarity.
- Adjusted the calculation of `totalValue` to use `batchCalls`.
- Modified the payload to use destructured `paymaster` and `paymasterInput`.
- Added a test case to verify the passing of additional arguments to `sendTransactionInternal`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->