### PR TITLE
Add hook to revoke sessions

### DIFF
--- a/.changeset/cyan-steaks-relax.md
+++ b/.changeset/cyan-steaks-relax.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Add useRevokeSessions hook

--- a/packages/agw-react/src/exports/index.ts
+++ b/packages/agw-react/src/exports/index.ts
@@ -4,4 +4,5 @@ export { useCreateSession } from '../hooks/useCreateSession.js';
 export { useGlobalWalletSignerAccount } from '../hooks/useGlobalWalletSignerAccount.js';
 export { useGlobalWalletSignerClient } from '../hooks/useGlobalWalletSignerClient.js';
 export { useLoginWithAbstract } from '../hooks/useLoginWithAbstract.js';
+export { useRevokeSessions } from '../hooks/useRevokeSessions.js';
 export { useWriteContractSponsored } from '../hooks/useWriteContractSponsored.js';

--- a/packages/agw-react/src/hooks/useRevokeSessions.ts
+++ b/packages/agw-react/src/hooks/useRevokeSessions.ts
@@ -17,6 +17,17 @@ export type RevokeSessionsArgs = {
 export const useRevokeSessions = () => {
   const { writeContract, writeContractAsync, ...writeContractRest } =
     useWriteContract();
+  const getSessionHashes = (
+    sessions: SessionConfig | Hash | (SessionConfig | Hash)[],
+  ): Hash[] => {
+    return typeof sessions === 'string'
+      ? [sessions as Hash]
+      : Array.isArray(sessions)
+        ? sessions.map((session) =>
+            typeof session === 'string' ? session : getSessionHash(session),
+          )
+        : [getSessionHash(sessions)];
+  };
 
   return {
     revokeSessions: (params: RevokeSessionsArgs) => {
@@ -44,15 +55,3 @@ export const useRevokeSessions = () => {
     ...writeContractRest,
   };
 };
-
-function getSessionHashes(
-  sessions: SessionConfig | Hash | (SessionConfig | Hash)[],
-): Hash[] {
-  return typeof sessions === 'string'
-    ? [sessions as Hash]
-    : Array.isArray(sessions)
-      ? sessions.map((session) =>
-          typeof session === 'string' ? session : getSessionHash(session),
-        )
-      : [getSessionHash(sessions)];
-}

--- a/packages/agw-react/src/hooks/useRevokeSessions.ts
+++ b/packages/agw-react/src/hooks/useRevokeSessions.ts
@@ -1,0 +1,58 @@
+import { sessionKeyValidatorAddress } from '@abstract-foundation/agw-client/constants';
+import { getSessionHash } from '@abstract-foundation/agw-client/dist/types/sessions';
+import {
+  type SessionConfig,
+  SessionKeyValidatorAbi,
+} from '@abstract-foundation/agw-client/sessions';
+import type { WriteContractParameters } from '@wagmi/core';
+import type { Address, Hash, Hex } from 'viem';
+import { useWriteContract } from 'wagmi';
+
+export type RevokeSessionsArgs = {
+  sessions: SessionConfig | Hash | (SessionConfig | Hash)[];
+  paymaster?: Address;
+  paymasterData?: Hex;
+} & Omit<WriteContractParameters, 'address' | 'abi' | 'functionName' | 'args'>;
+
+export const useRevokeSessions = () => {
+  const { writeContract, writeContractAsync, ...writeContractRest } =
+    useWriteContract();
+
+  return {
+    revokeSessions: (params: RevokeSessionsArgs) => {
+      const { sessions, ...rest } = params;
+      const sessionHashes = getSessionHashes(sessions);
+      writeContract({
+        address: sessionKeyValidatorAddress,
+        abi: SessionKeyValidatorAbi,
+        functionName: 'revokeKeys',
+        args: sessionHashes,
+        ...(rest as any),
+      });
+    },
+    revokeSessionsAsync: async (params: RevokeSessionsArgs) => {
+      const { sessions, ...rest } = params;
+      const sessionHashes = getSessionHashes(sessions);
+      await writeContractAsync({
+        address: sessionKeyValidatorAddress,
+        abi: SessionKeyValidatorAbi,
+        functionName: 'revokeKeys',
+        args: [sessionHashes],
+        ...(rest as any),
+      });
+    },
+    ...writeContractRest,
+  };
+};
+
+function getSessionHashes(
+  sessions: SessionConfig | Hash | (SessionConfig | Hash)[],
+): Hash[] {
+  return typeof sessions === 'string'
+    ? [sessions as Hash]
+    : Array.isArray(sessions)
+      ? sessions.map((session) =>
+          typeof session === 'string' ? session : getSessionHash(session),
+        )
+      : [getSessionHash(sessions)];
+}

--- a/packages/agw-react/src/hooks/useRevokeSessions.ts
+++ b/packages/agw-react/src/hooks/useRevokeSessions.ts
@@ -37,7 +37,7 @@ export const useRevokeSessions = () => {
         address: sessionKeyValidatorAddress,
         abi: SessionKeyValidatorAbi,
         functionName: 'revokeKeys',
-        args: sessionHashes,
+        args: [sessionHashes],
         ...(rest as any),
       });
     },


### PR DESCRIPTION
### Overview
This PR is intended to address the feature request in #139. In #137, a new hook was added to create sessions. Following a similar approach, and by looking into the [revokeSessions](https://github.com/Abstract-Foundation/agw-sdk/blob/main/packages/agw-client/src/actions/revokeSessions.ts) action implementation, I tried my hand at creating a hook to revoke one more sessions.
 - Added helper function to get session hashes
 - Added `useRevokeSessions` hook
 - Exported `useRevokeSessions` hook

### Testing
Since I am a new contributor to this repository, I am not 100% on the best way to test my changes. I understand that we can use sessions to temporarily whitelist certain contracts so that signing is only required once. I was trying to test this out by forking and cloning [create-abstract-app-template](https://github.com/Abstract-Foundation/create-abstract-app-template) and using the new hook there. Is this the recommended approach or can we add some sort of unit tests for new hooks?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new hook called `useRevokeSessions` in the `@abstract-foundation/agw-react` package, allowing users to revoke session keys. It includes functionality for both synchronous and asynchronous revocation of sessions.

### Detailed summary
- Added `useRevokeSessions` hook in `packages/agw-react/src/hooks/useRevokeSessions.ts`.
- Defined `RevokeSessionsArgs` type for parameters.
- Implemented `getSessionHashes` function to handle session inputs.
- Created `revokeSessions` and `revokeSessionsAsync` methods for revocation.
- Exported `useRevokeSessions` in `packages/agw-react/src/exports/index.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->