### PR TITLE
fix: update privy cross app flow to return smart account and signer addresses

### DIFF
--- a/.changeset/shy-crabs-join.md
+++ b/.changeset/shy-crabs-join.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Update privy cross app flow to return both smart account and signer addresses


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `usePrivyCrossAppProvider` functionality to enhance the handling of user wallets by returning both `smartAccount` and `signer` addresses instead of just one address. This improves the cross-app flow for users.

### Detailed summary
- Modified `getAddressFromUser` to `getAddressesFromUser` to return an object containing both `smartAccount` and `signer`.
- Updated the logic to retrieve `smartAccount` and `signer` addresses from the `user` object.
- Adjusted the return statement in `usePrivyCrossAppProvider` to include both addresses in an array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->