### PR TITLE
fix: make privy ready check more aggressive to prevent empty wallet list

### DIFF
--- a/.changeset/plenty-scissors-watch.md
+++ b/.changeset/plenty-scissors-watch.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Make privy ready check more aggressive to prevent empty wagmi context

--- a/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
+++ b/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
@@ -127,7 +127,13 @@ export const usePrivyCrossAppProvider = ({
       const address = getAddressFromUser(contextUser);
       return address ? [address] : [];
     },
-    [user, authenticated, ready, loginWithCrossAppAccount, linkCrossAppAccount],
+    [
+      user,
+      authenticated,
+      privyReady,
+      loginWithCrossAppAccount,
+      linkCrossAppAccount,
+    ],
   );
 
   const eventListeners = new Map<string, ((...args: any[]) => void)[]>();

--- a/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
+++ b/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
@@ -44,7 +44,7 @@ export const usePrivyCrossAppProvider = ({
     signMessage,
     signTypedData,
   } = useCrossAppAccounts();
-  const { user, authenticated, ready } = usePrivy();
+  const { user, authenticated, ready: privyReady } = usePrivy();
 
   const passthroughMethods = {
     web3_clientVersion: true,
@@ -208,6 +208,18 @@ export const usePrivyCrossAppProvider = ({
       request: handleRequest as EIP1193RequestFn<EIP1474Methods>,
     };
   }, [handleRequest]);
+
+  const ready = useMemo(() => {
+    return (
+      privyReady &&
+      user &&
+      authenticated &&
+      user.linkedAccounts.some(
+        (account) =>
+          account.type === 'cross_app' && account.providerApp.id === AGW_APP_ID,
+      )
+    );
+  }, [privyReady, user, authenticated]);
 
   return {
     ready,


### PR DESCRIPTION
- **cross app: make privy ready check much more aggressive**
- **changeset**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `privy` ready check in the `usePrivyCrossAppProvider` to ensure it is more robust, preventing scenarios with an empty `wagmi` context.

### Detailed summary
- Renamed the `ready` variable to `privyReady` for clarity.
- Updated the dependency array for the `usePrivy` hook.
- Introduced a new `ready` computed value using `useMemo` to check multiple conditions for readiness, including user accounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->