### PR TITLE
fix: Dependent query in useAbstractClient should not be enabled until first query is complete

### DIFF
--- a/.changeset/giant-wombats-enjoy.md
+++ b/.changeset/giant-wombats-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Fix query running before dependency is complete

--- a/packages/agw-react/src/hooks/useAbstractClient.ts
+++ b/packages/agw-react/src/hooks/useAbstractClient.ts
@@ -5,13 +5,16 @@ import { custom, useChains } from 'wagmi';
 import { useGlobalWalletSignerClient } from './useGlobalWalletSignerClient.js';
 
 export const useAbstractClient = () => {
-  const { data: signer } = useGlobalWalletSignerClient();
+  const { data: signer, status, error } = useGlobalWalletSignerClient();
   const [chain] = useChains();
 
   return useQuery({
     gcTime: 0,
     queryKey: ['abstractClient'],
-    queryFn: () => {
+    queryFn: async () => {
+      if (error) {
+        throw error;
+      }
       if (!signer) {
         throw new Error('No signer found');
       }
@@ -25,5 +28,6 @@ export const useAbstractClient = () => {
 
       return client;
     },
+    enabled: status !== 'pending',
   });
 };


### PR DESCRIPTION
- **fix: enabled flag for dependent query in useAbstractClient**
- **changeset**

See [query client docs](https://tanstack.com/query/latest/docs/framework/react/guides/dependent-queries) on dependent queries

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `useAbstractClient` hook by adding error handling and adjusting the query execution based on the status of the `useGlobalWalletSignerClient` dependency.

### Detailed summary
- Added `status` and `error` to the destructured return from `useGlobalWalletSignerClient()`.
- Updated the `queryFn` to throw an error if `error` is present.
- Modified the `query` configuration to enable it only if `status` is not 'pending'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->