### PR TITLE
fix: update useCreateSession to add module if not exists; use wagmi query pattern

### DIFF
--- a/.changeset/clever-fans-rush.md
+++ b/.changeset/clever-fans-rush.md
@@ -1,0 +1,6 @@
+---
+'@abstract-foundation/agw-client': patch
+'@abstract-foundation/agw-react': patch
+---
+
+Update useCreateSession to add module if not installed

--- a/packages/agw-client/src/exports/constants.ts
+++ b/packages/agw-client/src/exports/constants.ts
@@ -1,3 +1,4 @@
+import AGWAccountAbi from '../abis/AGWAccount.js';
 import {
   AGW_REGISTRY_ADDRESS,
   EOA_VALIDATOR_ADDRESS,
@@ -6,6 +7,7 @@ import {
 } from '../constants.js';
 
 export {
+  AGWAccountAbi as AGWAccountAbi,
   AGW_REGISTRY_ADDRESS as agwRegistryAddress,
   SESSION_KEY_VALIDATOR_ADDRESS as sessionKeyValidatorAddress,
   SMART_ACCOUNT_FACTORY_ADDRESS as smartAccountFactoryAddress,

--- a/packages/agw-client/src/exports/sessions.ts
+++ b/packages/agw-client/src/exports/sessions.ts
@@ -15,6 +15,7 @@ import type {
 } from '../sessions.js';
 import {
   ConstraintCondition,
+  encodeSession,
   getSessionHash,
   LimitType,
   LimitUnlimited,
@@ -26,6 +27,7 @@ export {
   type Constraint,
   ConstraintCondition,
   createSessionClient,
+  encodeSession,
   getSessionHash,
   type Limit,
   LimitType,

--- a/packages/agw-react/src/hooks/useCreateSession.ts
+++ b/packages/agw-react/src/hooks/useCreateSession.ts
@@ -1,11 +1,23 @@
-import { sessionKeyValidatorAddress } from '@abstract-foundation/agw-client/constants';
+import { type SessionConfig } from '@abstract-foundation/agw-client/sessions';
+import { useMutation } from '@tanstack/react-query';
+import type {
+  Config,
+  ResolvedRegister,
+  WriteContractErrorType,
+  WriteContractParameters,
+} from '@wagmi/core';
+import { type Address, type Hex } from 'viem';
+import { useConfig } from 'wagmi';
+import type { ConfigParameter } from 'wagmi/dist/types/types/properties.js';
+import type { UseMutationParameters, UseMutationReturnType } from 'wagmi/query';
+
 import {
-  type SessionConfig,
-  SessionKeyValidatorAbi,
-} from '@abstract-foundation/agw-client/sessions';
-import type { WriteContractParameters } from '@wagmi/core';
-import type { Address, Hex } from 'viem';
-import { useWriteContract } from 'wagmi';
+  type CreateSessionData,
+  type CreateSessionMutate,
+  type CreateSessionMutateAsync,
+  createSessionMutationOptions,
+  type CreateSessionVariables,
+} from '../query/createSession.js';
 
 export type CreateSessionArgs = {
   session: SessionConfig;
@@ -13,31 +25,53 @@ export type CreateSessionArgs = {
   paymasterData?: Hex;
 } & Omit<WriteContractParameters, 'address' | 'abi' | 'functionName' | 'args'>;
 
-export const useCreateSession = () => {
-  const { writeContract, writeContractAsync, ...writeContractRest } =
-    useWriteContract();
-
-  return {
-    useCreateSession: (params: CreateSessionArgs) => {
-      const { session, ...rest } = params;
-      writeContract({
-        address: sessionKeyValidatorAddress,
-        abi: SessionKeyValidatorAbi,
-        functionName: 'createSession',
-        args: [session as never],
-        ...(rest as any),
-      });
-    },
-    useCreateSessionAsync: async (params: CreateSessionArgs) => {
-      const { session, ...rest } = params;
-      await writeContractAsync({
-        address: sessionKeyValidatorAddress,
-        abi: SessionKeyValidatorAbi,
-        functionName: 'createSession',
-        args: [session as any],
-        ...(rest as any),
-      });
-    },
-    ...writeContractRest,
-  };
+export type UseCreateSessionParameters<
+  config extends Config = Config,
+  context = unknown,
+> = ConfigParameter<config> & {
+  mutation?:
+    | UseMutationParameters<
+        CreateSessionData,
+        WriteContractErrorType,
+        CreateSessionVariables<config, config['chains'][number]['id']>,
+        context
+      >
+    | undefined;
 };
+
+export type UseCreateSessionReturnType<
+  config extends Config = Config,
+  context = unknown,
+> = UseMutationReturnType<
+  CreateSessionData,
+  WriteContractErrorType,
+  CreateSessionVariables<config, config['chains'][number]['id']>,
+  context
+> & {
+  createSession: CreateSessionMutate<config, context>;
+  createSessionAsync: CreateSessionMutateAsync<config, context>;
+};
+
+export function useCreateSession<
+  config extends Config = ResolvedRegister['config'],
+  context = unknown,
+>(
+  parameters: UseCreateSessionParameters<config, context> = {},
+): UseCreateSessionReturnType<config, context> {
+  const { mutation } = parameters;
+
+  const config = useConfig(parameters);
+
+  const mutationOptions = createSessionMutationOptions(config);
+  const { mutate, mutateAsync, ...result } = useMutation({
+    ...mutation,
+    ...mutationOptions,
+  });
+
+  type Return = UseCreateSessionReturnType<config, context>;
+  return {
+    ...result,
+    createSession: mutate as Return['createSession'],
+    createSessionAsync: mutateAsync as Return['createSessionAsync'],
+  };
+}

--- a/packages/agw-react/src/query/createSession.ts
+++ b/packages/agw-react/src/query/createSession.ts
@@ -1,0 +1,189 @@
+import {
+  AGWAccountAbi,
+  sessionKeyValidatorAddress,
+} from '@abstract-foundation/agw-client/constants';
+import {
+  encodeSession,
+  type SessionConfig,
+  SessionKeyValidatorAbi,
+} from '@abstract-foundation/agw-client/sessions';
+import type { MutateOptions, MutationOptions } from '@tanstack/query-core';
+import { getConnectorClient, readContract, writeContract } from '@wagmi/core';
+import type {
+  ChainIdParameter,
+  Compute,
+  ConnectorParameter,
+  SelectChains,
+  UnionCompute,
+} from '@wagmi/core/internal';
+import {
+  type Account,
+  type Address,
+  BaseError,
+  type Chain,
+  type Client,
+  concatHex,
+  type DeriveChain,
+  type FormattedTransactionRequest,
+  type GetChainParameter,
+  type Hash,
+  type Hex,
+  type Prettify,
+  type UnionEvaluate,
+  type UnionOmit,
+  type WriteContractErrorType,
+} from 'viem';
+import type { GetAccountParameter } from 'viem/_types/types/account';
+import { type Config } from 'wagmi';
+
+export function createSessionMutationOptions<config extends Config>(
+  config: config,
+) {
+  return {
+    mutationFn: async (variables) => {
+      const {
+        session,
+        account: account_,
+        chainId,
+        connector,
+        ...rest
+      } = variables;
+
+      let client: Client;
+      if (account_ && typeof account_ === 'object' && account_.type === 'local')
+        client = config.getClient({ chainId });
+      else
+        client = await getConnectorClient(config, {
+          account: account_ ?? undefined,
+          chainId,
+          connector,
+        });
+
+      const account = client.account;
+      if (typeof account === 'undefined')
+        throw new BaseError('Account not found');
+
+      const validationHooks = await readContract(config, {
+        address: account.address,
+        abi: AGWAccountAbi,
+        functionName: 'listHooks',
+        args: [true],
+      });
+
+      const hasSessionModule = validationHooks.some(
+        (hook) => hook === sessionKeyValidatorAddress,
+      );
+
+      let transactionHash: Hash | undefined = undefined;
+
+      if (!hasSessionModule) {
+        const encodedSession = encodeSession(session);
+        transactionHash = await writeContract(config, {
+          address: account.address,
+          abi: AGWAccountAbi,
+          functionName: 'addModule',
+          args: [concatHex([sessionKeyValidatorAddress, encodedSession])],
+          account: account_,
+          chainId,
+          connector,
+          ...rest,
+        });
+      } else {
+        transactionHash = await writeContract(config, {
+          address: sessionKeyValidatorAddress,
+          abi: SessionKeyValidatorAbi,
+          functionName: 'createSession',
+          args: [session as never],
+          account: account_,
+          chainId,
+          connector,
+          ...rest,
+        });
+      }
+
+      return {
+        transactionHash,
+        session,
+      };
+    },
+    mutationKey: ['createSession'],
+  } as const satisfies MutationOptions<
+    CreateSessionData,
+    WriteContractErrorType,
+    CreateSessionVariables<config, config['chains'][number]['id']>
+  >;
+}
+
+type innerCreateSessionVariables<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+  chainOverride extends Chain | undefined = Chain | undefined,
+  derivedChain extends Chain | undefined = DeriveChain<chain, chainOverride>,
+> = GetChainParameter<chain, chainOverride> &
+  Prettify<
+    GetAccountParameter<account, Account | Address, true, true> & {
+      /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
+      dataSuffix?: Hex | undefined;
+    }
+  > &
+  UnionEvaluate<
+    UnionOmit<
+      FormattedTransactionRequest<derivedChain>,
+      'data' | 'from' | 'to' | 'value'
+    >
+  > & {
+    session: SessionConfig;
+    paymaster?: Address;
+    paymasterInput?: Hex;
+  };
+
+export interface CreateSessionData {
+  transactionHash: Hash | undefined;
+  session: SessionConfig;
+}
+
+export type CreateSessionVariables<
+  config extends Config,
+  chainId extends
+    config['chains'][number]['id'] = config['chains'][number]['id'],
+  chains extends readonly Chain[] = SelectChains<config, chainId>,
+> = UnionCompute<
+  {
+    [key in keyof chains]: innerCreateSessionVariables<
+      chains[key],
+      Account,
+      chains[key]
+    >;
+  }[number] &
+    Compute<ChainIdParameter<config, chainId>> &
+    ConnectorParameter
+>;
+
+export type CreateSessionMutate<config extends Config, context = unknown> = <
+  chainId extends config['chains'][number]['id'],
+>(
+  variables: CreateSessionVariables<config, chainId>,
+  options?:
+    | MutateOptions<
+        CreateSessionData,
+        WriteContractErrorType,
+        CreateSessionVariables<config, chainId>,
+        context
+      >
+    | undefined,
+) => void;
+
+export type CreateSessionMutateAsync<
+  config extends Config,
+  context = unknown,
+> = <chainId extends config['chains'][number]['id']>(
+  variables: CreateSessionVariables<config, chainId>,
+  options?:
+    | MutateOptions<
+        CreateSessionData,
+        WriteContractErrorType,
+        CreateSessionVariables<config, config['chains'][number]['id']>,
+        context
+      >
+    | undefined,
+) => Promise<CreateSessionData>;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `useCreateSession` hook in the `@abstract-foundation/agw-react` package to enhance its functionality by adding a module if it is not already installed. 

### Detailed summary
- Added `encodeSession` to `packages/agw-client/src/exports/sessions.ts`.
- Exported `AGWAccountAbi` in `packages/agw-client/src/exports/constants.ts`.
- Updated `useCreateSession` in `packages/agw-react/src/hooks/useCreateSession.ts` to include mutation options.
- Implemented logic to check and add a module in `createSessionMutationOptions` in `packages/agw-react/src/query/createSession.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->