### PR TITLE
fix(eip-5792): wallet_getCallsStatus returns correct return type for spec

### DIFF
--- a/.changeset/warm-fans-shout.md
+++ b/.changeset/warm-fans-shout.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Fix EIP-5792 return type on wallet_getCallsStatus

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -222,10 +222,14 @@ export function transformEIP1193Provider(
         });
       }
       case 'wallet_getCallsStatus': {
-        return await provider.request({
+        const receipt = await provider.request({
           method: 'eth_getTransactionReceipt',
           params,
         });
+        return {
+          status: receipt?.status === undefined ? 'PENDING' : 'CONFIRMED',
+          receipts: [receipt],
+        };
       }
       case 'wallet_showCallsStatus': {
         // not implemented


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the return type for the `wallet_getCallsStatus` method in the `agw-client` package to ensure it returns a structured response based on the transaction receipt.

### Detailed summary
- Changed the return statement in the `wallet_getCallsStatus` case.
- Introduced a `const receipt` to store the result of `provider.request`.
- Updated the return object to include:
  - `status`: 'PENDING' if `receipt?.status` is undefined, otherwise 'CONFIRMED'.
  - `receipts`: an array containing the `receipt`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->