### PR TITLE
privy login options

### DIFF
--- a/.changeset/kind-brooms-clap.md
+++ b/.changeset/kind-brooms-clap.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Don't override privy login options if they are provided

--- a/packages/agw-react/src/exports/privy.ts
+++ b/packages/agw-react/src/exports/privy.ts
@@ -1,2 +1,5 @@
-export { AbstractPrivyProvider } from '../privy/abstractPrivyProvider.js';
+export {
+  AbstractPrivyProvider,
+  agwAppLoginMethod,
+} from '../privy/abstractPrivyProvider.js';
 export { useAbstractPrivyLogin } from '../privy/useAbstractPrivyLogin.js';

--- a/packages/agw-react/src/privy/abstractPrivyProvider.tsx
+++ b/packages/agw-react/src/privy/abstractPrivyProvider.tsx
@@ -12,7 +12,7 @@ import { createConfig, http, WagmiProvider } from 'wagmi';
 import { AGW_APP_ID } from '../constants.js';
 import { InjectWagmiConnector } from './injectWagmiConnector.js';
 
-const privyAppLoginMethod: LoginMethodOrderOption = `privy:${AGW_APP_ID}`;
+export const agwAppLoginMethod: LoginMethodOrderOption = `privy:${AGW_APP_ID}`;
 
 /**
  * Configuration options for the AbstractPrivyProvider.
@@ -44,34 +44,17 @@ export const AbstractPrivyProvider = ({
   });
   const queryClient = new QueryClient();
 
+  // if no login methods and order are provided, set the default login method to the privy app login method
   if (!props.config) {
     props.config = {
       loginMethodsAndOrder: {
-        primary: [privyAppLoginMethod],
+        primary: [agwAppLoginMethod],
       },
     };
   } else if (!props.config.loginMethodsAndOrder) {
     props.config.loginMethodsAndOrder = {
-      primary: [privyAppLoginMethod],
+      primary: [agwAppLoginMethod],
     };
-  } else {
-    if (
-      // check if the privy app login method is in the primary or overflow list
-      !(
-        props.config.loginMethodsAndOrder.primary.includes(
-          privyAppLoginMethod,
-        ) ||
-        (props.config.loginMethodsAndOrder.overflow &&
-          props.config.loginMethodsAndOrder.overflow.includes(
-            privyAppLoginMethod,
-          ))
-      )
-    ) {
-      props.config.loginMethodsAndOrder.primary = [
-        privyAppLoginMethod,
-        ...props.config.loginMethodsAndOrder.primary,
-      ];
-    }
   }
   return (
     <PrivyProvider {...props}>


### PR DESCRIPTION
- **fix: don't override privy provider login options if they are provided**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `agw-react` package to ensure that the `agwAppLoginMethod` is used consistently instead of `privyAppLoginMethod` for login configuration. It also simplifies the logic around setting login methods.

### Detailed summary
- Changed `privyAppLoginMethod` to `agwAppLoginMethod` in `abstractPrivyProvider.tsx`.
- Updated the default login method logic to use `agwAppLoginMethod`.
- Removed redundant checks for `privyAppLoginMethod` in the login method configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->