### PR TITLE
fix: create/revoke session actions don't work for manually created client

### DIFF
--- a/.changeset/eight-trains-vanish.md
+++ b/.changeset/eight-trains-vanish.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Fixed an issue that would occur in session key actions when creating an Abstract Client using the account and provider from another client as the signer

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -159,10 +159,8 @@ export function globalWalletActions<
     client: Client<Transport, ChainEIP712, Account>,
   ): AbstractWalletActions<Chain, Account> => ({
     getChainId: () => getChainId(client),
-    createSession: (args) =>
-      createSession(client, signerClient, publicClient, args, isPrivyCrossApp),
-    revokeSessions: (args) =>
-      revokeSessions(client, signerClient, publicClient, args, isPrivyCrossApp),
+    createSession: (args) => createSession(client, publicClient, args),
+    revokeSessions: (args) => revokeSessions(client, args),
     prepareAbstractTransactionRequest: (args) =>
       prepareTransactionRequest(
         client,

--- a/packages/agw-client/test/src/actions/createSession.test.ts
+++ b/packages/agw-client/test/src/actions/createSession.test.ts
@@ -20,14 +20,12 @@ import { isSmartAccountDeployed } from '../../../src/utils.js';
 import { anvilAbstractTestnet } from '../../anvil.js';
 import { address } from '../../constants.js';
 vi.mock('../../../src/utils.js');
-vi.mock('../../../src/actions/sendTransaction', () => ({
-  sendTransaction: vi.fn(),
-}));
 
-import { readContract } from 'viem/actions';
+import { readContract, writeContract } from 'viem/actions';
 
 vi.mock('viem/actions', () => ({
   readContract: vi.fn(),
+  writeContract: vi.fn(),
 }));
 
 import AGWAccountAbi from '../../../src/abis/AGWAccount.js';
@@ -64,7 +62,7 @@ beforeEach(() => {
 
 test('should create a session with module already installed', async () => {
   vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
-  vi.mocked(sendTransaction).mockResolvedValue('0xmockedTransactionHash');
+  vi.mocked(writeContract).mockResolvedValue('0xmockedTransactionHash');
   vi.mocked(readContract).mockResolvedValue([SESSION_KEY_VALIDATOR_ADDRESS]);
 
   const session: SessionConfig = {
@@ -79,22 +77,16 @@ test('should create a session with module already installed', async () => {
     },
   };
 
-  const { transactionHash } = await createSession(
-    baseClient,
-    signerClient,
-    publicClient,
-    {
-      session,
-    },
-    false,
-  );
+  const { transactionHash } = await createSession(baseClient, publicClient, {
+    session,
+  });
 
   expect(transactionHash).toBe('0xmockedTransactionHash');
 });
 
 test('should add module and create a session with contract not deployed', async () => {
   vi.mocked(isSmartAccountDeployed).mockResolvedValue(false);
-  vi.mocked(sendTransaction).mockResolvedValue('0xmockedTransactionHash');
+  vi.mocked(writeContract).mockResolvedValue('0xmockedTransactionHash');
   vi.mocked(readContract).mockResolvedValue([]);
 
   const session: SessionConfig = {
@@ -109,41 +101,23 @@ test('should add module and create a session with contract not deployed', async 
     },
   };
 
-  const { transactionHash } = await createSession(
-    baseClient,
-    signerClient,
-    publicClient,
-    {
-      session,
-    },
-    false,
-  );
+  const { transactionHash } = await createSession(baseClient, publicClient, {
+    session,
+  });
 
   expect(transactionHash).toBe('0xmockedTransactionHash');
 
-  expect(sendTransaction).toHaveBeenCalledWith(
-    baseClient,
-    signerClient,
-    publicClient,
-    {
-      account: baseClient.account,
-      chain: anvilAbstractTestnet.chain as ChainEIP712,
-      to: address.smartAccountAddress,
-      data: encodeFunctionData({
-        abi: AGWAccountAbi,
-        functionName: 'addModule',
-        args: [
-          concatHex([SESSION_KEY_VALIDATOR_ADDRESS, encodeSession(session)]),
-        ],
-      }),
-    },
-    false,
-  );
+  expect(writeContract).toHaveBeenCalledWith(baseClient, {
+    address: address.smartAccountAddress,
+    abi: AGWAccountAbi,
+    functionName: 'addModule',
+    args: [concatHex([SESSION_KEY_VALIDATOR_ADDRESS, encodeSession(session)])],
+  });
 });
 
 test('should add module and create a session with module not installed', async () => {
   vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
-  vi.mocked(sendTransaction).mockResolvedValue('0xmockedTransactionHash');
+  vi.mocked(writeContract).mockResolvedValue('0xmockedTransactionHash');
   vi.mocked(readContract).mockResolvedValue([]);
 
   const session: SessionConfig = {
@@ -158,34 +132,17 @@ test('should add module and create a session with module not installed', async (
     },
   };
 
-  const { transactionHash } = await createSession(
-    baseClient,
-    signerClient,
-    publicClient,
-    {
-      session,
-    },
-    false,
-  );
+  const { transactionHash } = await createSession(baseClient, publicClient, {
+    session,
+  });
 
   expect(transactionHash).toBe('0xmockedTransactionHash');
 
-  expect(sendTransaction).toHaveBeenCalledWith(
-    baseClient,
-    signerClient,
-    publicClient,
-    {
-      account: baseClient.account,
-      chain: anvilAbstractTestnet.chain as ChainEIP712,
-      to: address.smartAccountAddress,
-      data: encodeFunctionData({
-        abi: AGWAccountAbi,
-        functionName: 'addModule',
-        args: [
-          concatHex([SESSION_KEY_VALIDATOR_ADDRESS, encodeSession(session)]),
-        ],
-      }),
-    },
-    false,
-  );
+  expect(writeContract).toHaveBeenCalledWith(baseClient, {
+    address: address.smartAccountAddress,
+    abi: AGWAccountAbi,
+    functionName: 'addModule',
+
+    args: [concatHex([SESSION_KEY_VALIDATOR_ADDRESS, encodeSession(session)])],
+  });
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `createSession` and `revokeSessions` functions in the `agw-client` package. It simplifies the parameters by removing the `signerClient` and `publicClient` arguments and replaces `sendTransaction` calls with `writeContract`. 

### Detailed summary
- Updated the `createSession` and `revokeSessions` functions to remove `signerClient` and `publicClient` parameters.
- Replaced `sendTransaction` calls with `writeContract` in both functions.
- Added optional `paymaster` and `paymasterInput` parameters in `CreateSessionParameters` and `RevokeSessionsParameters`.
- Adjusted test cases to reflect the changes in function signatures and assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->