### PR TITLE
chore: tag prerelease packages with `next`

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -34,6 +34,6 @@ jobs:
         run: pnpm build
 
       - name: Publish packages
-        run: pnpm -r publish --no-git-checks --access public
+        run: pnpm -r publish --no-git-checks --access public ${{ github.event.release.prerelease == true && '--tag next' || '--tag latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the `publish-npm-packages.yml` workflow to conditionally set the npm publish tag based on whether the GitHub release is a pre-release.

### Detailed summary
- Updated the `run` command in the workflow to conditionally use `--tag next` for pre-releases and `--tag latest` for regular releases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->