### PR TITLE
fix: throw error in `getSmartAccountAddressFromInitialSigner` if initial signer is undefined

### DIFF
--- a/.changeset/nine-pears-run.md
+++ b/.changeset/nine-pears-run.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Fix getSmartAccountAddressFromInitialSigner to throw if initial signer is undefined

--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -49,6 +49,9 @@ export async function getSmartAccountAddressFromInitialSigner<
   initialSigner: Address,
   publicClient: PublicClient<Transport, chain>,
 ): Promise<Hex> {
+  if (initialSigner === undefined) {
+    throw new Error('Initial signer is required to get smart account address');
+  }
   // Generate salt based off address
   const addressBytes = toBytes(initialSigner);
   const salt = keccak256(addressBytes);

--- a/packages/agw-client/test/src/utils.test.ts
+++ b/packages/agw-client/test/src/utils.test.ts
@@ -53,6 +53,17 @@ describe('convertBigIntToString', () => {
 });
 
 describe('getSmartAccountAddressFromInitialSigner', () => {
+  it('should throw an error if initial signer is undefined', async () => {
+    const publicClient = {
+      readContract: vi.fn().mockResolvedValue(address.smartAccountAddress),
+    };
+    expect(
+      getSmartAccountAddressFromInitialSigner(undefined!, publicClient as any),
+    ).rejects.toThrowError(
+      'Initial signer is required to get smart account address',
+    );
+  });
+
   it('should return the smart account address', () => {
     const initialSigner = address.signerAddress;
     const publicClient = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `getSmartAccountAddressFromInitialSigner` function by adding error handling for cases where the `initialSigner` is undefined, ensuring that it throws an appropriate error message.

### Detailed summary
- Modified `getSmartAccountAddressFromInitialSigner` to throw an error if `initialSigner` is undefined.
- Added a test case in `utils.test.ts` to verify that an error is thrown when `initialSigner` is undefined.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->