### PR TITLE
Simplify gas estimation flow

### DIFF
--- a/.changeset/nine-parrots-join.md
+++ b/.changeset/nine-parrots-join.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Use gas estimation from zks_estimateFee instead of making a separate call for eth_estimateGas

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -314,6 +314,7 @@ export async function prepareTransactionRequest<
     });
   }
 
+  let gasFromFeeEstimation: bigint | undefined;
   if (parameters.includes('fees')) {
     if (
       typeof request.maxFeePerGas === 'undefined' ||
@@ -346,6 +347,7 @@ export async function prepareTransactionRequest<
         );
         maxFeePerGas = feeEstimation.maxFeePerGas;
         maxPriorityFeePerGas = feeEstimation.maxPriorityFeePerGas;
+        gasFromFeeEstimation = feeEstimation.gasLimit;
       }
 
       if (
@@ -359,10 +361,15 @@ export async function prepareTransactionRequest<
 
       request.maxPriorityFeePerGas = maxPriorityFeePerGas;
       request.maxFeePerGas = maxFeePerGas;
+      request.gas = gasFromFeeEstimation;
     }
   }
 
-  if (parameters.includes('gas') && typeof gas === 'undefined')
+  if (
+    parameters.includes('gas') &&
+    typeof gas === 'undefined' &&
+    gasFromFeeEstimation === undefined // if gas was set by fee estimation, don't estimate again
+  )
     request.gas = await getAction(
       client,
       estimateGas,

--- a/packages/agw-client/test/src/actions/prepareTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/prepareTransaction.test.ts
@@ -20,7 +20,8 @@ import { address } from '../../constants.js';
 
 const RAW_SIGNATURE =
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-const MOCK_GAS_LIMIT = 158774n;
+const MOCK_ETH_ESTIMATE_GAS_LIMIT = 158774n;
+const MOCK_ZKS_ESTIMATE_GAS_LIMIT = 1403904n;
 const MOCK_FEE_PER_GAS = 250000001n;
 const MOCK_NONCE = 34;
 
@@ -35,7 +36,7 @@ const baseClientRequestSpy = vi.fn(async ({ method, params }) => {
     return anvilAbstractTestnet.chain.id;
   }
   if (method === 'eth_estimateGas') {
-    return MOCK_GAS_LIMIT;
+    return MOCK_ETH_ESTIMATE_GAS_LIMIT;
   }
   return anvilAbstractTestnet.getClient().request({ method, params } as any);
 });
@@ -63,7 +64,7 @@ const publicClient = createPublicClient({
 publicClient.request = (async ({ method, params }) => {
   if (method === 'zks_estimateFee') {
     return {
-      gas_limit: '0x156c00',
+      gas_limit: toHex(MOCK_ZKS_ESTIMATE_GAS_LIMIT),
       gas_per_pubdata_limit: '0x143b',
       max_fee_per_gas: toHex(MOCK_FEE_PER_GAS),
       max_priority_fee_per_gas: '0x0',
@@ -98,7 +99,7 @@ test('minimum', async () => {
     chain: anvilAbstractTestnet.chain,
     from: address.smartAccountAddress,
     chainId: anvilAbstractTestnet.chain.id,
-    gas: MOCK_GAS_LIMIT,
+    gas: MOCK_ZKS_ESTIMATE_GAS_LIMIT,
     nonce: MOCK_NONCE,
     maxFeePerGas: MOCK_FEE_PER_GAS,
     maxPriorityFeePerGas: 0n,
@@ -121,7 +122,7 @@ test('is initial transaction', async () => {
     from: address.signerAddress,
     chain: anvilAbstractTestnet.chain,
     chainId: anvilAbstractTestnet.chain.id,
-    gas: MOCK_GAS_LIMIT,
+    gas: MOCK_ZKS_ESTIMATE_GAS_LIMIT,
     nonce: MOCK_NONCE,
     maxFeePerGas: MOCK_FEE_PER_GAS,
     maxPriorityFeePerGas: 0n,
@@ -146,7 +147,7 @@ test('with fees', async () => {
     chain: anvilAbstractTestnet.chain,
     from: address.smartAccountAddress,
     chainId: anvilAbstractTestnet.chain.id,
-    gas: MOCK_GAS_LIMIT,
+    gas: MOCK_ETH_ESTIMATE_GAS_LIMIT,
     nonce: MOCK_NONCE,
     maxFeePerGas: 10000n,
     maxPriorityFeePerGas: 0n,
@@ -171,7 +172,7 @@ test('to contract deployer', async () => {
     chain: anvilAbstractTestnet.chain,
     from: address.smartAccountAddress,
     chainId: anvilAbstractTestnet.chain.id,
-    gas: MOCK_GAS_LIMIT,
+    gas: MOCK_ETH_ESTIMATE_GAS_LIMIT,
     nonce: MOCK_NONCE,
     maxFeePerGas: 25000000n, // Default fee for contract deployments
     maxPriorityFeePerGas: 0n,
@@ -192,7 +193,7 @@ test('with chainId but not chain', async () => {
     ...transaction,
     from: address.smartAccountAddress,
     chainId: anvilAbstractTestnet.chain.id,
-    gas: MOCK_GAS_LIMIT,
+    gas: MOCK_ZKS_ESTIMATE_GAS_LIMIT,
     nonce: MOCK_NONCE,
     maxFeePerGas: MOCK_FEE_PER_GAS,
     maxPriorityFeePerGas: 0n,
@@ -210,7 +211,7 @@ test('with no chainId or chain', async () => {
     ...transaction,
     from: address.smartAccountAddress,
     chainId: anvilAbstractTestnet.chain.id,
-    gas: MOCK_GAS_LIMIT,
+    gas: MOCK_ZKS_ESTIMATE_GAS_LIMIT,
     nonce: MOCK_NONCE,
     maxFeePerGas: MOCK_FEE_PER_GAS,
     maxPriorityFeePerGas: 0n,


### PR DESCRIPTION
- **fix: Use estimated gas from zks_estimateFee instead of calling eth_estimateGas if fee params are not provided.**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the gas estimation process in the `agw-client` package by utilizing `zks_estimateFee` for gas limits instead of `eth_estimateGas`. This change aims to streamline gas estimation and improve efficiency in transaction preparation.

### Detailed summary
- Changed gas estimation to use `zks_estimateFee` instead of `eth_estimateGas`.
- Added `gasFromFeeEstimation` variable to store gas limit from fee estimation.
- Updated test cases to reflect new gas limit variables: `MOCK_ETH_ESTIMATE_GAS_LIMIT` and `MOCK_ZKS_ESTIMATE_GAS_LIMIT`.
- Adjusted conditions to prevent redundant gas estimation when already provided by fee estimation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->