### PR TITLE
fix: check for validation hooks when raw signing eip 712 tx data

### DIFF
--- a/packages/agw-client/src/actions/signTypedData.ts
+++ b/packages/agw-client/src/actions/signTypedData.ts
@@ -9,12 +9,14 @@ import {
   type WalletClient,
 } from 'viem';
 import type { SignTypedDataParameters } from 'viem/accounts';
-import { signTypedData as viemSignTypedData } from 'viem/actions';
+import { readContract, signTypedData as viemSignTypedData } from 'viem/actions';
 import type { ChainEIP712 } from 'viem/chains';
+import { getAction } from 'viem/utils';
 
+import AGWAccountAbi from '../abis/AGWAccount.js';
 import { EOA_VALIDATOR_ADDRESS } from '../constants.js';
-import { isEIP712Transaction } from '../eip712.js';
 import { getAgwTypedSignature } from '../getAgwTypedSignature.js';
+import { isEip712TypedData } from '../utils.js';
 import { sendPrivySignTypedData } from './sendPrivyTransaction.js';
 
 export async function signTypedData(
@@ -27,17 +29,28 @@ export async function signTypedData(
 
   // if the typed data is already a zkSync EIP712 transaction, don't try to transform it
   // to an AGW typed signature, just pass it through to the signer.
-  if (
-    parameters.message &&
-    parameters.domain?.name === 'zkSync' &&
-    isEIP712Transaction(parameters.message)
-  ) {
+  if (isEip712TypedData(parameters)) {
     const rawSignature = await viemSignTypedData(signerClient, parameters);
     // Match the expect signature format of the AGW smart account so the result can be
     // directly used in eth_sendRawTransaction as the customSignature field
+    const hookData: Hex[] = [];
+    const validationHooks = await getAction(
+      client,
+      readContract,
+      'readContract',
+    )({
+      address: client.account.address,
+      abi: AGWAccountAbi,
+      functionName: 'listHooks',
+      args: [true],
+    });
+    for (const _ of validationHooks) {
+      hookData.push('0x');
+    }
+
     const signature = encodeAbiParameters(
       parseAbiParameters(['bytes', 'address', 'bytes[]']),
-      [rawSignature, EOA_VALIDATOR_ADDRESS, []],
+      [rawSignature, EOA_VALIDATOR_ADDRESS, hookData],
     );
     return signature;
   }

--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -8,9 +8,14 @@ import {
   keccak256,
   type PublicClient,
   toBytes,
+  toHex,
   type Transport,
+  type TypedDataDefinition,
 } from 'viem';
-import { abstractTestnet } from 'viem/chains';
+import {
+  abstractTestnet,
+  type ZksyncEIP712TransactionSignable,
+} from 'viem/chains';
 import { type ChainEIP712 } from 'viem/zksync';
 
 import AccountFactoryAbi from './abis/AccountFactory.js';
@@ -19,6 +24,7 @@ import {
   AGW_REGISTRY_ADDRESS,
   SMART_ACCOUNT_FACTORY_ADDRESS,
 } from './constants.js';
+import { isEIP712Transaction } from './eip712.js';
 import { type Call } from './types/call.js';
 
 // TODO: support Abstract mainnet
@@ -139,4 +145,13 @@ export function transformHexValues(transaction: any, keys: string[]) {
       transaction[key] = fromHex(transaction[key], 'bigint');
     }
   }
+}
+
+export function isEip712TypedData(typedData: TypedDataDefinition): boolean {
+  return (
+    typedData.message &&
+    typedData.domain?.name === 'zkSync' &&
+    typedData.domain.version === '2' &&
+    isEIP712Transaction(typedData.message)
+  );
 }

--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -8,14 +8,10 @@ import {
   keccak256,
   type PublicClient,
   toBytes,
-  toHex,
   type Transport,
   type TypedDataDefinition,
 } from 'viem';
-import {
-  abstractTestnet,
-  type ZksyncEIP712TransactionSignable,
-} from 'viem/chains';
+import { abstractTestnet } from 'viem/chains';
 import { type ChainEIP712 } from 'viem/zksync';
 
 import AccountFactoryAbi from './abis/AccountFactory.js';

--- a/packages/agw-client/test/src/actions/signTypedData.test.ts
+++ b/packages/agw-client/test/src/actions/signTypedData.test.ts
@@ -32,6 +32,7 @@ import AccountFactoryAbi from '../../../src/abis/AccountFactory.js';
 import { signTypedData } from '../../../src/actions/signTypedData.js';
 import {
   EOA_VALIDATOR_ADDRESS,
+  SESSION_KEY_VALIDATOR_ADDRESS,
   SMART_ACCOUNT_FACTORY_ADDRESS,
 } from '../../../src/constants.js';
 import { getInitializerCalldata } from '../../../src/utils.js';
@@ -58,7 +59,9 @@ const baseClientRequestSpy = vi.fn(async ({ method, params }) => {
       )
     ) {
       console.log('returning listHooks');
-      return encodeAbiParameters(parseAbiParameters(['address[]']), [[]]);
+      return encodeAbiParameters(parseAbiParameters(['address[]']), [
+        [SESSION_KEY_VALIDATOR_ADDRESS],
+      ]);
     }
   }
   return anvilAbstractTestnet.getClient().request({ method, params } as any);

--- a/packages/agw-client/test/src/actions/signTypedData.test.ts
+++ b/packages/agw-client/test/src/actions/signTypedData.test.ts
@@ -139,7 +139,7 @@ describe('signTypedData', async () => {
       encodeAbiParameters(parseAbiParameters(['bytes', 'address', 'bytes[]']), [
         RAW_SIGNATURE,
         EOA_VALIDATOR_ADDRESS,
-        [],
+        ['0x'],
       ]),
     );
   });

--- a/packages/agw-client/test/src/actions/signTypedData.test.ts
+++ b/packages/agw-client/test/src/actions/signTypedData.test.ts
@@ -1,4 +1,11 @@
-import { fromHex, toBytes, zeroAddress } from 'viem';
+import {
+  Address,
+  fromHex,
+  Hex,
+  toBytes,
+  toFunctionSelector,
+  zeroAddress,
+} from 'viem';
 import {
   createClient,
   createWalletClient,
@@ -36,8 +43,23 @@ const RAW_SIGNATURE =
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
 const baseClientRequestSpy = vi.fn(async ({ method, params }) => {
+  console.log('method', method);
   if (method === 'privy_signSmartWalletTypedData') {
     return RAW_SIGNATURE;
+  } else if (method === 'eth_call') {
+    const callParams = params as {
+      to: Address;
+      data: Hex;
+    }[];
+    if (
+      callParams[0].to === address.smartAccountAddress &&
+      callParams[0].data.startsWith(
+        toFunctionSelector('function listHooks(bool)'),
+      )
+    ) {
+      console.log('returning listHooks');
+      return encodeAbiParameters(parseAbiParameters(['address[]']), [[]]);
+    }
   }
   return anvilAbstractTestnet.getClient().request({ method, params } as any);
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `isEip712TypedData` function to validate EIP712 typed data and modifies the `signTypedData` function to utilize this validation. It also enhances the testing suite to accommodate new behaviors and updates the handling of hooks.

### Detailed summary
- Added `isEip712TypedData` function in `utils.ts` to validate typed data.
- Updated `signTypedData` to use `isEip712TypedData` for processing EIP712 transactions.
- Enhanced test cases in `signTypedData.test.ts` to reflect new logic.
- Adjusted hook data handling in `signTypedData` to include validation hooks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->