### PR TITLE
fix: don't override gas parameter if it's passed into prepareTransaction

### DIFF
--- a/.changeset/lazy-moose-bake.md
+++ b/.changeset/lazy-moose-bake.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Fixes prepareTransaction action so it does not override a manual gas value passed in

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -361,7 +361,10 @@ export async function prepareTransactionRequest<
 
       request.maxPriorityFeePerGas = maxPriorityFeePerGas;
       request.maxFeePerGas = maxFeePerGas;
-      request.gas = gasFromFeeEstimation;
+      // set gas to gasFromFeeEstimation if gas is not already set
+      if (typeof gas === 'undefined') {
+        request.gas = gasFromFeeEstimation;
+      }
     }
   }
 


### PR DESCRIPTION
- **fix: check for validation hooks when raw signing eip 712 tx data**
- **fix: don't override existing gas param value if it's passed into prepareTransaction**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `prepareTransaction` action in the `@abstract-foundation/agw-client` package to ensure that a manually set gas value is not overridden by an estimated gas value.

### Detailed summary
- Updated `prepareTransaction` in `packages/agw-client/src/actions/prepareTransaction.ts`.
- Added a condition to only set `request.gas` to `gasFromFeeEstimation` if `gas` is `undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->