### PR TITLE
fix default chain

### DIFF
--- a/.changeset/tidy-icons-repeat.md
+++ b/.changeset/tidy-icons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+fix: Update wagmi connector to prefer chain object from config instead of defaultChains

--- a/packages/agw-react/src/abstractWalletConnector.ts
+++ b/packages/agw-react/src/abstractWalletConnector.ts
@@ -88,10 +88,12 @@ function abstractWalletConnector(
       parameters?: { chainId?: number | undefined } | undefined,
     ) => {
       const chainId = parameters?.chainId ?? defaultChain.id;
-      const chain = validChains[chainId];
-      if (!chain) {
+      if (!validChains[chainId]) {
         throw new Error('Unsupported chain');
       }
+      const chain =
+        params.chains.find((c) => c.id === chainId) ?? validChains[chainId];
+
       const provider = await connector.getProvider({
         chainId,
       });


### PR DESCRIPTION
- **fix: prefer chain from config over validChains**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `wagmi` connector in the `agw-react` package to prioritize the chain object from the configuration instead of relying on `defaultChains`. 

### Detailed summary
- Updated the logic in `abstractWalletConnector.ts` to prefer the chain object from `params.chains`.
- Removed the direct assignment of `chain` from `validChains` and added a check for the chain's existence.
- Improved error handling for unsupported chains.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->