### PR TITLE
fix link typing

### DIFF
--- a/.changeset/thin-icons-reply.md
+++ b/.changeset/thin-icons-reply.md
@@ -1,0 +1,6 @@
+---
+'@abstract-foundation/agw-react': minor
+'@abstract-foundation/web3-react-agw': minor
+---
+
+Fix typing for wallet extension

--- a/packages/agw-client/src/actions/linkToAgw.ts
+++ b/packages/agw-client/src/actions/linkToAgw.ts
@@ -3,6 +3,7 @@ import {
   type Account,
   type Address,
   type Chain,
+  type Client,
   createPublicClient,
   decodeEventLog,
   encodeFunctionData,
@@ -10,7 +11,6 @@ import {
   http,
   type PublicClient,
   type Transport,
-  type WalletClient,
 } from 'viem';
 import { writeContract } from 'viem/actions';
 import { getAction, parseAccount } from 'viem/utils';
@@ -41,7 +41,7 @@ export interface LinkToAgwReturnType {
 }
 
 export async function linkToAgw(
-  client: WalletClient<Transport, Chain, Account>,
+  client: Client<Transport, Chain, Account>,
   parameters: LinkToAgwParameters,
 ): Promise<LinkToAgwReturnType> {
   const {

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -225,7 +225,10 @@ export function globalWalletActions<
     client: Client<Transport, ChainEIP712, Account>,
   ): AbstractWalletActions<Chain, Account> => ({
     getChainId: () => getChainId(client),
-    getLinkedAccounts: (args) => getLinkedAccounts(client, args),
+    getLinkedAccounts: () =>
+      getLinkedAccounts(client, {
+        agwAddress: parseAccount(client.account).address,
+      }),
     isLinkedAccount: (args) => isLinkedAccount(client, args),
     createSession: (args) => createSession(client, publicClient, args),
     revokeSessions: (args) => revokeSessions(client, args),
@@ -301,7 +304,7 @@ export function globalWalletActions<
 
 export function linkableWalletActions() {
   return (
-    client: WalletClient<Transport, Chain, Account>,
+    client: Client<Transport, Chain, Account>,
   ): LinkableWalletActions => ({
     linkToAgw: (args) => linkToAgw(client, args),
     getLinkedAgw: () =>


### PR DESCRIPTION
- **fix typing for wallet actions**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing typing for the `wallet` extension in the `agw-client` package, specifically updating the types used for the `client` parameter in various functions.

### Detailed summary
- Updated `client` type from `WalletClient` to `Client` in `linkToAgw` function.
- Modified `getLinkedAccounts` function to pass `agwAddress` from `client.account` in `walletActions.ts`.
- Adjusted the type signature for `linkableWalletActions` to use the new `Client` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->