### PR TITLE
fix: more typing fixes for link account actions

### DIFF
--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -29,6 +29,11 @@
       "import": "./dist/esm/exports/index.js",
       "require": "./dist/cjs/exports/index.js"
     },
+    "./actions": {
+      "types": "./dist/types/exports/actions.d.ts",
+      "import": "./dist/esm/exports/actions.js",
+      "require": "./dist/cjs/exports/actions.js"
+    },
     "./constants": {
       "types": "./dist/types/exports/constants.d.ts",
       "import": "./dist/esm/exports/constants.js",
@@ -42,6 +47,9 @@
   },
   "typesVersions": {
     "*": {
+      "actions": [
+        "./dist/types/exports/actions.d.ts"
+      ],
       "constants": [
         "./dist/types/exports/constants.d.ts"
       ],

--- a/packages/agw-client/src/actions/getLinkedAccounts.ts
+++ b/packages/agw-client/src/actions/getLinkedAccounts.ts
@@ -31,8 +31,12 @@ export interface IsLinkedAccountParameters {
   address: Address;
 }
 
-export async function getLinkedAccounts(
-  client: Client<Transport, ChainEIP712, Account>,
+export async function getLinkedAccounts<
+  transport extends Transport = Transport,
+  chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  account extends Account | undefined = Account | undefined,
+>(
+  client: Client<transport, chain, account>,
   parameters: GetLinkedAccountsParameters,
 ): Promise<GetLinkedAccountsReturnType> {
   const { agwAddress } = parameters;

--- a/packages/agw-client/src/actions/getLinkedAgw.ts
+++ b/packages/agw-client/src/actions/getLinkedAgw.ts
@@ -1,6 +1,8 @@
 import {
   type Account,
   type Address,
+  BaseError,
+  type Chain,
   type Client,
   getAddress,
   InvalidAddressError,
@@ -23,18 +25,25 @@ export interface GetLinkedAgwReturnType {
 }
 
 export interface GetLinkedAgwParameters {
-  address: Address;
+  address?: Address | undefined;
 }
 
 export interface IsLinkedAccountParameters {
   address: Address;
 }
 
-export async function getLinkedAgw(
-  client: Client<Transport, ChainEIP712, Account>,
+export async function getLinkedAgw<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+>(
+  client: Client<Transport, chain, account>,
   parameters: GetLinkedAgwParameters,
 ): Promise<GetLinkedAgwReturnType> {
-  const { address } = parameters;
+  const { address = client.account?.address } = parameters;
+
+  if (address === undefined) {
+    throw new BaseError('No address provided');
+  }
 
   if (!isAddress(address, { strict: false })) {
     throw new InvalidAddressError({ address });

--- a/packages/agw-client/src/actions/linkToAgw.ts
+++ b/packages/agw-client/src/actions/linkToAgw.ts
@@ -3,7 +3,6 @@ import {
   type Account,
   type Address,
   type Chain,
-  type Client,
   createPublicClient,
   decodeEventLog,
   encodeFunctionData,
@@ -11,6 +10,7 @@ import {
   http,
   type PublicClient,
   type Transport,
+  type WalletClient,
 } from 'viem';
 import { writeContract } from 'viem/actions';
 import { getAction, parseAccount } from 'viem/utils';
@@ -40,8 +40,12 @@ export interface LinkToAgwReturnType {
   getL2TransactionHash: () => Promise<Hash>;
 }
 
-export async function linkToAgw(
-  client: Client<Transport, Chain, Account>,
+export async function linkToAgw<
+  transport extends Transport = Transport,
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+>(
+  client: WalletClient<transport, chain, account>,
   parameters: LinkToAgwParameters,
 ): Promise<LinkToAgwReturnType> {
   const {
@@ -140,7 +144,7 @@ export async function linkToAgw(
     args: [bridgeArgs],
     maxFeePerGas,
     maxPriorityFeePerGas,
-  });
+  } as any);
 
   return {
     l1TransactionHash,
@@ -149,8 +153,11 @@ export async function linkToAgw(
   };
 }
 
-async function getL2HashFromPriorityOp(
-  publicClient: PublicClient,
+async function getL2HashFromPriorityOp<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+>(
+  publicClient: PublicClient<Transport, chain, account>,
   l1TransactionHash: Hash,
 ): Promise<Hash> {
   const receipt = await publicClient.waitForTransactionReceipt({

--- a/packages/agw-client/src/exports/actions.ts
+++ b/packages/agw-client/src/exports/actions.ts
@@ -1,0 +1,4 @@
+export { deployAccount } from '../actions/deployAccount.js';
+export { getLinkedAccounts } from '../actions/getLinkedAccounts.js';
+export { getLinkedAgw } from '../actions/getLinkedAgw.js';
+export { linkToAgw } from '../actions/linkToAgw.js';

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -15,6 +15,7 @@ import {
   type SignTypedDataReturnType,
   type Transport,
   type WalletActions,
+  walletActions,
   type WalletClient,
   type WriteContractParameters,
 } from 'viem';
@@ -154,10 +155,13 @@ export type SessionClientActions<
   signTypedData: WalletActions<chain, account>['signTypedData'];
 };
 
-export interface LinkableWalletActions {
+export type LinkableWalletActions<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+> = WalletActions<chain, account> & {
   linkToAgw: (args: LinkToAgwParameters) => Promise<LinkToAgwReturnType>;
   getLinkedAgw: () => Promise<GetLinkedAgwReturnType>;
-}
+};
 
 export interface LinkablePublicActions {
   getLinkedAgw: (
@@ -302,19 +306,27 @@ export function globalWalletActions<
   });
 }
 
-export function linkableWalletActions() {
+export function linkableWalletActions<
+  transport extends Transport = Transport,
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+>() {
   return (
-    client: Client<Transport, Chain, Account>,
-  ): LinkableWalletActions => ({
+    client: WalletClient<transport, chain, account>,
+  ): LinkableWalletActions<chain, account> => ({
+    ...walletActions(client),
     linkToAgw: (args) => linkToAgw(client, args),
-    getLinkedAgw: () =>
-      getLinkedAgw(client, { address: parseAccount(client.account).address }),
+    getLinkedAgw: () => getLinkedAgw(client, {}),
   });
 }
 
-export function linkablePublicActions() {
+export function linkablePublicActions<
+  transport extends Transport = Transport,
+  chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  account extends Account | undefined = Account | undefined,
+>() {
   return (
-    client: Client<Transport, ChainEIP712, Account>,
+    client: Client<transport, chain, account>,
   ): LinkablePublicActions => ({
     getLinkedAgw: (args) => getLinkedAgw(client, args),
     getLinkedAccounts: (args) => getLinkedAccounts(client, args),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `actions` module by exporting additional action functions, improving type definitions, and refactoring several functions to use more generic types. It also updates the `package.json` to reflect these changes.

### Detailed summary
- Added exports for `deployAccount`, `getLinkedAccounts`, `getLinkedAgw`, and `linkToAgw` in `actions.ts`.
- Updated `package.json` to include new paths for `actions`.
- Refactored `getLinkedAccounts` and `getLinkedAgw` functions to use generic types.
- Made `address` parameter optional in `GetLinkedAgwParameters`.
- Updated `linkToAgw` to accept a `WalletClient`.
- Enhanced `getL2HashFromPriorityOp` with generics for better type handling.
- Modified `linkableWalletActions` and `linkablePublicActions` to use generics for `Client`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->