### PR TITLE
update config to allow passing in a chain

### DIFF
--- a/packages/agw-client/src/abstractClient.ts
+++ b/packages/agw-client/src/abstractClient.ts
@@ -43,6 +43,7 @@ interface CreateAbstractClientParameters {
   transport?: Transport;
   address?: Address;
   isPrivyCrossApp?: boolean;
+  publicTransport?: Transport;
 }
 
 type AbstractClientActions = AbstractWalletActions<ChainEIP712, Account>;
@@ -56,14 +57,15 @@ export async function createAbstractClient({
   transport,
   address,
   isPrivyCrossApp = false,
+  publicTransport = http(),
 }: CreateAbstractClientParameters): Promise<AbstractClient> {
   if (!transport) {
-    transport = http();
+    throw new Error('Transport is required');
   }
 
   const publicClient = createPublicClient({
     chain: chain,
-    transport: http(),
+    transport: publicTransport,
   });
 
   const smartAccountAddress =
@@ -76,7 +78,7 @@ export async function createAbstractClient({
   const baseClient = createClient({
     account: toAccount(smartAccountAddress),
     chain: chain,
-    transport,
+    transport: publicTransport,
   });
 
   // Create a signer wallet client to handle actual signing

--- a/packages/agw-client/src/sessionClient.ts
+++ b/packages/agw-client/src/sessionClient.ts
@@ -68,7 +68,7 @@ export function createSessionClient({
   }
 
   const publicClient = createPublicClient({
-    transport: http(),
+    transport,
     chain,
   });
 

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -54,6 +54,7 @@ async function getAgwClient(
   chain: Chain,
   transport: Transport,
   isPrivyCrossApp: boolean,
+  overrideTransport?: Transport,
 ) {
   const wallet = createWalletClient({
     account,
@@ -72,6 +73,7 @@ async function getAgwClient(
     signer,
     transport,
     isPrivyCrossApp,
+    publicTransport: overrideTransport,
   });
 
   return abstractClient;
@@ -87,7 +89,7 @@ export function transformEIP1193Provider(
     isPrivyCrossApp = false,
   } = options;
 
-  const transport = overrideTransport ?? custom(provider);
+  const transport = custom(provider);
 
   const handler: EIP1193RequestFn<EIP1474Methods> = async (e: any) => {
     const { method, params } = e;
@@ -135,6 +137,7 @@ export function transformEIP1193Provider(
           chain,
           transport,
           isPrivyCrossApp,
+          overrideTransport,
         );
 
         return abstractClient.signTypedData(JSON.parse(params[1]));
@@ -153,6 +156,7 @@ export function transformEIP1193Provider(
           chain,
           transport,
           isPrivyCrossApp,
+          overrideTransport,
         );
 
         return await abstractClient.signMessage({
@@ -178,6 +182,7 @@ export function transformEIP1193Provider(
           chain,
           transport,
           isPrivyCrossApp,
+          overrideTransport,
         );
 
         // Undo the automatic formatting applied by Wagmi's eth_signTransaction
@@ -213,6 +218,7 @@ export function transformEIP1193Provider(
           chain,
           transport,
           isPrivyCrossApp,
+          overrideTransport,
         );
 
         return await abstractClient.sendTransactionBatch({

--- a/packages/agw-client/test/src/abstractClient.test.ts
+++ b/packages/agw-client/test/src/abstractClient.test.ts
@@ -74,6 +74,15 @@ describe('createAbstractClient', () => {
     );
   };
 
+  it('throws if no transport is provided', () => {
+    expect(
+      createAbstractClient({
+        signer,
+        chain: anvilAbstractTestnet.chain as ChainEIP712,
+      }),
+    ).rejects.toThrow();
+  });
+
   it('creates client with default public transport', async () => {
     const mockTransport = vi.fn();
     const mockPublicTransport = expect.any(Function);

--- a/packages/agw-client/test/src/abstractClient.test.ts
+++ b/packages/agw-client/test/src/abstractClient.test.ts
@@ -74,24 +74,28 @@ describe('createAbstractClient', () => {
     );
   };
 
-  it('creates client without transport', async () => {
-    const mockTransport = expect.any(Function);
-    const abstractClient = await createAbstractClient({
-      signer,
-      chain: anvilAbstractTestnet.chain as ChainEIP712,
-    });
-
-    testAbstractClient(abstractClient, mockTransport);
-  });
-
-  it('creates client with custom transport', async () => {
+  it('creates client with default public transport', async () => {
     const mockTransport = vi.fn();
+    const mockPublicTransport = expect.any(Function);
     const abstractClient = await createAbstractClient({
       signer,
       chain: anvilAbstractTestnet.chain as ChainEIP712,
       transport: mockTransport,
     });
 
-    testAbstractClient(abstractClient, mockTransport);
+    testAbstractClient(abstractClient, mockPublicTransport);
+  });
+
+  it('creates client with custom public transport', async () => {
+    const mockTransport = vi.fn();
+    const mockPublicTransport = vi.fn();
+    const abstractClient = await createAbstractClient({
+      signer,
+      chain: anvilAbstractTestnet.chain as ChainEIP712,
+      transport: mockTransport,
+      publicTransport: mockPublicTransport,
+    });
+
+    testAbstractClient(abstractClient, mockPublicTransport);
   });
 });

--- a/packages/agw-client/test/src/sessionClient.test.ts
+++ b/packages/agw-client/test/src/sessionClient.test.ts
@@ -92,30 +92,15 @@ describe('createSessionClient', () => {
     expect(getSmartAccountAddressFromInitialSigner).not.toHaveBeenCalled();
   };
 
-  it('creates client without transport', async () => {
-    const mockTransport = expect.any(Function);
-    const abstractClient = await createAbstractClient({
-      signer,
-      chain: anvilAbstractTestnet.chain as ChainEIP712,
-      address: address.smartAccountAddress,
-    });
-
-    const sessionClient = toSessionClient({
-      client: abstractClient,
-      signer: sessionSigner,
-      session,
-    });
-
-    testSessionClient(sessionClient, mockTransport);
-  });
-
   it('creates client with custom transport', async () => {
-    const mockTransport = vi.fn();
+    const mockTransport = expect.any(Function);
+    const mockReadTransport = vi.fn();
     const abstractClient = await createAbstractClient({
       signer,
       chain: anvilAbstractTestnet.chain as ChainEIP712,
       address: address.smartAccountAddress,
       transport: mockTransport,
+      publicTransport: mockReadTransport,
     });
 
     const sessionClient = toSessionClient({

--- a/packages/agw-react/src/abstractWalletConnector.ts
+++ b/packages/agw-react/src/abstractWalletConnector.ts
@@ -10,7 +10,6 @@ import {
   type EIP1193RequestFn,
   type EIP1474Methods,
   http,
-  type Transport,
 } from 'viem';
 
 import { AGW_APP_ID, ICON_URL } from './constants.js';
@@ -18,8 +17,6 @@ import { AGW_APP_ID, ICON_URL } from './constants.js';
 interface AbstractWalletConnectorOptions {
   /** RainbowKit connector details */
   rkDetails: WalletDetailsParams;
-  /** Override transports for chains */
-  overrideTransports: Record<number, Transport>;
 }
 
 /**
@@ -59,8 +56,7 @@ function abstractWalletConnector(
   Record<string, unknown>,
   Record<string, unknown>
 > {
-  const { rkDetails, overrideTransports } = options;
-
+  const { rkDetails } = options;
   return (params) => {
     const chains = [...params.chains];
     let defaultChain = params.chains[0];
@@ -98,16 +94,7 @@ function abstractWalletConnector(
         chainId,
       });
 
-      const providerChainId = await provider.request({
-        method: 'eth_chainId',
-      });
-
-      let transport: Transport | undefined;
-      if (validChains[Number(providerChainId)] === undefined) {
-        // Transport is not overridden but provider is not on a supported chain,
-        // use default http transport
-        transport = overrideTransports?.[chainId] ?? http();
-      }
+      const transport = params.transports?.[chainId] ?? http();
 
       return transformEIP1193Provider({
         provider,

--- a/packages/agw-react/src/agwProvider.tsx
+++ b/packages/agw-react/src/agwProvider.tsx
@@ -1,6 +1,7 @@
+import { validChains } from '@abstract-foundation/agw-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { http, type Transport } from 'viem';
+import { type Chain, http, type Transport } from 'viem';
 import { abstractTestnet } from 'viem/chains';
 import { createConfig, WagmiProvider } from 'wagmi';
 
@@ -12,7 +13,7 @@ interface AbstractWalletConfig {
    * @type {boolean}
    * @default false
    */
-  testnet?: boolean;
+  chain: Chain;
   /**
    * Optional transport for the client.
    * @type {Transport}
@@ -45,14 +46,16 @@ interface AbstractWalletConfig {
  */
 export const AbstractWalletProvider = ({
   config = {
-    testnet: false,
+    chain: abstractTestnet,
     transport: http(),
   },
   children,
 }: React.PropsWithChildren<{ config: AbstractWalletConfig }>) => {
-  const { testnet = false, transport } = config;
-  // TODO: replace with mainnet when we have the configuration
-  const chain = testnet ? abstractTestnet : abstractTestnet;
+  const { chain, transport } = config;
+
+  if (!validChains[chain.id]) {
+    throw new Error(`Chain ${chain.id} is not supported`);
+  }
 
   const wagmiConfig = createConfig({
     chains: [chain],

--- a/packages/agw-react/src/agwProvider.tsx
+++ b/packages/agw-react/src/agwProvider.tsx
@@ -32,7 +32,7 @@ interface AbstractWalletConfig {
  * const App = () => {
  *   // optional configuration overrides
  *   const config = {
- *     testnet: true,
+ *     chain: abstractTestnet,
  *     transport: http("https://your.abstract.node.example.com/rpc")
  *   };
  *   return (

--- a/packages/agw-react/src/privy/abstractPrivyProvider.tsx
+++ b/packages/agw-react/src/privy/abstractPrivyProvider.tsx
@@ -1,3 +1,4 @@
+import { validChains } from '@abstract-foundation/agw-client';
 import {
   type LoginMethodOrderOption,
   PrivyProvider,
@@ -5,7 +6,7 @@ import {
 } from '@privy-io/react-auth';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { type Transport } from 'viem';
+import { type Chain, type Transport } from 'viem';
 import { abstractTestnet } from 'viem/chains';
 import { createConfig, http, WagmiProvider } from 'wagmi';
 
@@ -22,16 +23,18 @@ export const agwAppLoginMethod: LoginMethodOrderOption = `privy:${AGW_APP_ID}`;
  * @property {Transport} transport - Optional transport to use, defaults to standard http.
  */
 interface AgwPrivyProviderProps extends PrivyProviderProps {
-  testnet?: boolean;
+  chain?: Chain;
   transport?: Transport;
 }
 
 export const AbstractPrivyProvider = ({
-  testnet = false,
+  chain = abstractTestnet,
   transport,
   ...props
 }: AgwPrivyProviderProps) => {
-  const chain = testnet ? abstractTestnet : abstractTestnet;
+  if (!validChains[chain.id]) {
+    throw new Error(`Chain ${chain.id} is not supported`);
+  }
 
   const wagmiConfig = createConfig({
     chains: [chain],

--- a/packages/web3-react-agw/src/index.ts
+++ b/packages/web3-react-agw/src/index.ts
@@ -14,6 +14,7 @@ const AGW_APP_ID = 'cm04asygd041fmry9zmcyn5o5';
 
 const VALID_CHAINS: Record<number, Chain> = {
   [abstractTestnet.id]: abstractTestnet,
+  [2741]: { id: 2741 } as Chain,
 };
 
 function parseChainId(chainId: string | number) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on enhancing the transport handling in various client creation functions and tests, adding support for a `publicTransport` parameter, and validating chain IDs. It also updates tests to reflect these changes.

### Detailed summary
- Added `publicTransport` parameter in `createAbstractClient`.
- Updated `createPublicClient` to use `publicTransport`.
- Introduced validation for chain IDs in `AbstractPrivyProvider`.
- Modified tests to check for transport requirements and handle default transport scenarios.
- Removed unnecessary `overrideTransports` from `AbstractWalletConnectorOptions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->