### PR TITLE
export privy connector

### DIFF
--- a/.changeset/yellow-apricots-dance.md
+++ b/.changeset/yellow-apricots-dance.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Export privy InjectWagmiConnector for advanced usages

--- a/packages/agw-react/src/exports/privy.ts
+++ b/packages/agw-react/src/exports/privy.ts
@@ -2,4 +2,5 @@ export {
   AbstractPrivyProvider,
   agwAppLoginMethod,
 } from '../privy/abstractPrivyProvider.js';
+export { InjectWagmiConnector } from '../privy/injectWagmiConnector.js';
 export { useAbstractPrivyLogin } from '../privy/useAbstractPrivyLogin.js';

--- a/packages/agw-react/src/privy/injectWagmiConnector.tsx
+++ b/packages/agw-react/src/privy/injectWagmiConnector.tsx
@@ -7,9 +7,41 @@ import { injected } from 'wagmi/connectors';
 import { usePrivyCrossAppProvider } from './usePrivyCrossAppProvider.js';
 
 interface InjectWagmiConnectorProps extends React.PropsWithChildren {
+  /**
+   * The chain to connect to.
+   * @type {Chain}
+   */
   chain: Chain;
+  /**
+   * Optional transport configuration for the provider.
+   * @type {Transport}
+   * @optional
+   */
   transport?: Transport;
 }
+
+/**
+ * InjectWagmiConnector is a React component that injects the Abstract Wallet provider into Wagmi's connector system.
+ * It handles the setup and reconnection of the wallet provider when ready.
+ *
+ * @example
+ * ```tsx
+ * import { InjectWagmiConnector } from '@abstractwallet/agw-react';
+ *
+ * const App = () => {
+ *   return (
+ *     <InjectWagmiConnector chain={chain} transport={transport}>
+ *       <Component {...pageProps} />
+ *     </InjectWagmiConnector>
+ *   );
+ * };
+ * ```
+ *
+ * @param {InjectWagmiConnectorProps} props - The component props
+ * @param {Chain} props.chain - The blockchain network to connect to
+ * @param {Transport} [props.transport] - Optional transport configuration for the provider
+ * @param {React.ReactNode} props.children - Child components to render
+ */
 
 export const InjectWagmiConnector = (props: InjectWagmiConnectorProps) => {
   const { chain, transport, children } = props;


### PR DESCRIPTION
- **feat: export privy InjectWagmiConnector for advanced usages**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting the `InjectWagmiConnector` component from the `agw-react` package, enhancing its usability for advanced integrations with the Abstract Wallet provider.

### Detailed summary
- Updated `.changeset/yellow-apricots-dance.md` to include a patch for `@abstract-foundation/agw-react`.
- Exported `InjectWagmiConnector` from `packages/agw-react/src/exports/privy.ts`.
- Added detailed documentation for `InjectWagmiConnector` in `packages/agw-react/src/privy/injectWagmiConnector.tsx`.
- Defined `InjectWagmiConnectorProps` interface with `chain` and optional `transport` properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->