### PR TITLE
feat: add optional query client to agwProvider

### DIFF
--- a/.changeset/flat-files-exercise.md
+++ b/.changeset/flat-files-exercise.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Add optional queryClient to providers

--- a/packages/agw-react/src/agwProvider.tsx
+++ b/packages/agw-react/src/agwProvider.tsx
@@ -19,6 +19,12 @@ interface AbstractWalletConfig {
    * @default http()
    */
   transport?: Transport;
+  /**
+   * Optional query client.
+   * @type {QueryClient}
+   * @default new QueryClient()
+   */
+  queryClient?: QueryClient;
 }
 
 /**
@@ -31,9 +37,9 @@ interface AbstractWalletConfig {
  * const App = () => {
  *   // optional configuration overrides
  *   const transport = http("https://your.abstract.node.example.com/rpc")
- *
+ *   const queryClient = new QueryClient()
  *   return (
- *     <AbstractWalletProvider chain={abstractTestnet} transport={transport}>
+ *     <AbstractWalletProvider chain={abstractTestnet} transport={transport} queryClient={queryClient}>
  *       <Component {...pageProps} />
  *     </AbstractWalletProvider>
  *   );
@@ -44,6 +50,7 @@ interface AbstractWalletConfig {
 export const AbstractWalletProvider = ({
   chain,
   transport,
+  queryClient = new QueryClient(),
   children,
 }: React.PropsWithChildren<AbstractWalletConfig>) => {
   if (!validChains[chain.id]) {
@@ -60,7 +67,6 @@ export const AbstractWalletProvider = ({
     multiInjectedProviderDiscovery: false,
   });
 
-  const queryClient = new QueryClient();
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/packages/agw-react/src/agwProvider.tsx
+++ b/packages/agw-react/src/agwProvider.tsx
@@ -24,7 +24,7 @@ interface AbstractWalletConfig {
    * @type {QueryClient}
    * @default new QueryClient()
    */
-  queryClient?: QueryClient;
+  queryClient: QueryClient;
 }
 
 /**

--- a/packages/agw-react/src/privy/abstractPrivyProvider.tsx
+++ b/packages/agw-react/src/privy/abstractPrivyProvider.tsx
@@ -25,7 +25,7 @@ export const agwAppLoginMethod: LoginMethodOrderOption = `privy:${AGW_APP_ID}`;
 interface AgwPrivyProviderProps extends PrivyProviderProps {
   chain: Chain;
   transport?: Transport;
-  queryClient?: QueryClient;
+  queryClient: QueryClient;
 }
 
 export const AbstractPrivyProvider = ({

--- a/packages/agw-react/src/privy/abstractPrivyProvider.tsx
+++ b/packages/agw-react/src/privy/abstractPrivyProvider.tsx
@@ -20,15 +20,18 @@ export const agwAppLoginMethod: LoginMethodOrderOption = `privy:${AGW_APP_ID}`;
  * @extends PrivyProviderProps
  * @property {boolean} testnet - Whether to use abstract testnet, defaults to false.
  * @property {Transport} transport - Optional transport to use, defaults to standard http.
+ * @property {QueryClient} queryClient - Optional query client to use, defaults to a standard query client.
  */
 interface AgwPrivyProviderProps extends PrivyProviderProps {
   chain: Chain;
   transport?: Transport;
+  queryClient?: QueryClient;
 }
 
 export const AbstractPrivyProvider = ({
   chain,
   transport,
+  queryClient = new QueryClient(),
   ...props
 }: AgwPrivyProviderProps) => {
   if (!validChains[chain.id]) {
@@ -44,7 +47,6 @@ export const AbstractPrivyProvider = ({
     },
     multiInjectedProviderDiscovery: false,
   });
-  const queryClient = new QueryClient();
 
   // if no login methods and order are provided, set the default login method to the privy app login method
   if (!props.config) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces an optional `queryClient` property to the `AbstractPrivyProvider` and `AbstractWalletProvider` components, allowing users to specify a custom `QueryClient`. The default behavior remains unchanged, as a new `QueryClient` is created if none is provided.

### Detailed summary
- Added `queryClient` property to `AgwPrivyProviderProps` interface.
- Updated `AbstractPrivyProvider` to accept `queryClient`, defaulting to a new `QueryClient()`.
- Added `queryClient` property to `AbstractWalletConfig` interface.
- Updated `AbstractWalletProvider` to accept `queryClient`, defaulting to a new `QueryClient()`.
- Modified example usage in comments to include `queryClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->