### PR TITLE
remove wagmi disconnected shim before creating connector

### DIFF
--- a/.changeset/big-chairs-deliver.md
+++ b/.changeset/big-chairs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@abstract-foundation/agw-react": patch
+---
+
+remove wagmi disconnected shim before creating connector

--- a/packages/agw-react/src/privy/injectWagmiConnector.tsx
+++ b/packages/agw-react/src/privy/injectWagmiConnector.tsx
@@ -53,6 +53,7 @@ export const InjectWagmiConnector = (props: InjectWagmiConnectorProps) => {
 
   useEffect(() => {
     const setup = async (provider: EIP1193Provider) => {
+      config.storage?.removeItem('xyz.abs.privy.disconnected');
       const wagmiConnector = injected({
         target: {
           provider,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `agw-react` package by removing a disconnected shim for the `wagmi` connector, aiming to streamline the connection process.

### Detailed summary
- Updated `@abstract-foundation/agw-react` package to a patch version.
- Removed the line that calls `config.storage?.removeItem('xyz.abs.privy.disconnected')` in `injectWagmiConnector.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->