### PR TITLE
zks estimateFee

### DIFF
--- a/.changeset/spotty-birds-drive.md
+++ b/.changeset/spotty-birds-drive.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Allow passthru of zks_estimateFee to underlying provider in privy native flow

--- a/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
+++ b/packages/agw-react/src/privy/usePrivyCrossAppProvider.ts
@@ -92,6 +92,7 @@ export const usePrivyCrossAppProvider = ({
     eth_protocolVersion: true,
     eth_sendRawTransaction: true,
     eth_uninstallFilter: true,
+    zks_estimateFee: true,
   };
   const passthrough = (method: EIP1474MethodNames) =>
     !!passthroughMethods[method];


### PR DESCRIPTION
- **add zks_estimateFee to passthrough methods**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a patch for the `@abstract-foundation/agw-react` package, enabling the passthrough of the `zks_estimateFee` method to the underlying provider within the Privy native flow.

### Detailed summary
- Added `zks_estimateFee: true` to the `passthroughMethods` object in `usePrivyCrossAppProvider.ts`.
- Updated the `passthrough` function to include support for the new method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->