### PR TITLE
fix error in function 

### DIFF
--- a/packages/agw-client/src/abis/AGWAccount.ts
+++ b/packages/agw-client/src/abis/AGWAccount.ts
@@ -152,7 +152,7 @@ const AGWAccountAbi = [
   },
   {
     inputs: [],
-    name: 'RECUSIVE_MODULE_CALL',
+    name: 'RECURSIVE_MODULE_CALL',
     type: 'error',
   },
   {


### PR DESCRIPTION
'RECUSIVE_MODULE_CALL' - 'RECURSIVE_MODULE_CALL'

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the `name` property of an object within the `AGWAccount.ts` file.

### Detailed summary
- Changed the `name` property from `'RECUSIVE_MODULE_CALL'` to `'RECURSIVE_MODULE_CALL'` in the object that has `inputs` as an empty array and `type` as `'error'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->