### PR TITLE
chore: fix broken link 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/Abstr
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://gitlab.gnome.org/Archive/byzanz) on Linux.
 - **Explain why this enhancement would be useful** to most agw-sdk users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 ---


### PR DESCRIPTION
The official mirror is now on GitLab: https://gitlab.gnome.org/Archive/byzanz









<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `CONTRIBUTING.md` file by modifying a link related to recording GIFs on Linux.

### Detailed summary
- Changed the link for `byzanz` from GitHub to GitLab in the section about tools for recording GIFs on Linux.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->