### PR TITLE
custom paymaster handler on sendTransaction

### DIFF
--- a/packages/agw-client/src/actions/sendTransactionForSession.ts
+++ b/packages/agw-client/src/actions/sendTransactionForSession.ts
@@ -20,6 +20,7 @@ import {
   getPeriodIdsForTransaction,
   type SessionConfig,
 } from '../sessions.js';
+import type { CustomPaymasterHandler } from '../types/customPaymaster.js';
 import { isSmartAccountDeployed } from '../utils.js';
 import { sendTransactionInternal } from './sendTransactionInternal.js';
 
@@ -60,6 +61,7 @@ export async function sendTransactionForSession<
     request
   >,
   session: SessionConfig,
+  customPaymasterHandler: CustomPaymasterHandler | undefined = undefined,
 ): Promise<SendEip712TransactionReturnType> {
   const isDeployed = await isSmartAccountDeployed(
     publicClient,
@@ -94,5 +96,6 @@ export async function sendTransactionForSession<
         }),
       ),
     },
+    customPaymasterHandler,
   );
 }

--- a/packages/agw-client/src/actions/writeContractForSession.ts
+++ b/packages/agw-client/src/actions/writeContractForSession.ts
@@ -18,6 +18,7 @@ import { type ChainEIP712 } from 'viem/zksync';
 
 import { AccountNotFoundError } from '../errors/account.js';
 import type { SessionConfig } from '../sessions.js';
+import type { CustomPaymasterHandler } from '../types/customPaymaster.js';
 import { sendTransactionForSession } from './sendTransactionForSession.js';
 
 export async function writeContractForSession<
@@ -44,6 +45,7 @@ export async function writeContractForSession<
     chainOverride
   >,
   session: SessionConfig,
+  customPaymasterHandler: CustomPaymasterHandler | undefined = undefined,
 ): Promise<WriteContractReturnType> {
   const {
     abi,
@@ -79,6 +81,7 @@ export async function writeContractForSession<
         ...request,
       },
       session,
+      customPaymasterHandler,
     );
   } catch (error) {
     throw getContractError(error as BaseError, {

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -186,6 +186,7 @@ export function sessionWalletActions(
         publicClient,
         args,
         session,
+        paymasterHandler,
       ),
     writeContract: (args) =>
       writeContractForSession(
@@ -194,6 +195,7 @@ export function sessionWalletActions(
         publicClient,
         args,
         session,
+        paymasterHandler,
       ),
     signTransaction: (args) =>
       signTransactionForSession(


### PR DESCRIPTION
sendTransaction function is invoked when creating session client and sending txs like that, so we need customPaymasterHandler there too

```ts
const sessionClient = createSessionClient({
    account: account.address!,
    chain: abstractTestnet,
    signer: sessionSigner,
    session: session,
    paymasterHandler: () => { /* ... */ }
  });
    
await sessionClient.sendTransaction({
    account: account.address!, // OR maybe sessionClient.account
    to: "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA",
    data: encodeFunctionData({
      abi: MINT_ABI,
      functionName: "mint",
      args: [session.signer, BigInt(1)],
    }),
    chain: abstractTestnet,
  });
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new parameter, `customPaymasterHandler`, to several functions related to session management in the wallet actions. This enhancement allows for the use of a custom paymaster handler during contract writing and transaction sending processes.

### Detailed summary
- Added `customPaymasterHandler` parameter to `sessionWalletActions` function in `walletActions.ts`.
- Updated `sendTransactionForSession` to accept `customPaymasterHandler`.
- Modified `writeContractForSession` to include `customPaymasterHandler`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->