### PR TITLE
Fix chain sorting

### DIFF
--- a/.changeset/quick-seahorses-type.md
+++ b/.changeset/quick-seahorses-type.md
@@ -1,0 +1,13 @@
+---
+'@abstract-foundation/agw-client': patch
+'@abstract-foundation/agw-react': patch
+---
+
+Fix chains sorting
+
+Sorting alphabetically works well for strings ("Apple" comes before "Banana").
+But, sorting numbers can produce incorrect results.
+"25" is bigger than "100", because "2" is bigger than "1".
+
+This makes abstractTestnet to become defaultChain instead of abstractMainnet,
+which in turn can produce some issues on dApps using AGW with both Abstract testnet and mainnet.

--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -188,8 +188,8 @@ export function transformEip712TypedData(
     paymaster:
       (typedData.message['paymaster'] as string) != '0'
         ? toHex(BigInt(typedData.message['paymaster'] as string), {
-          size: 20,
-        })
+            size: 20,
+          })
         : undefined,
     nonce: typedData.message['nonce'] as number,
     value: BigInt(typedData.message['value'] as string),

--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -30,7 +30,6 @@ import {
 import { isEIP712Transaction } from './eip712.js';
 import { type Call } from './types/call.js';
 
-// TODO: support Abstract mainnet
 export const VALID_CHAINS: Record<number, Chain> = {
   [abstractTestnet.id]: abstractTestnet,
   [abstract.id]: abstract,
@@ -189,8 +188,8 @@ export function transformEip712TypedData(
     paymaster:
       (typedData.message['paymaster'] as string) != '0'
         ? toHex(BigInt(typedData.message['paymaster'] as string), {
-            size: 20,
-          })
+          size: 20,
+        })
         : undefined,
     nonce: typedData.message['nonce'] as number,
     value: BigInt(typedData.message['value'] as string),

--- a/packages/agw-react/src/abstractWalletConnector.ts
+++ b/packages/agw-react/src/abstractWalletConnector.ts
@@ -60,7 +60,7 @@ function abstractWalletConnector(
   return (params) => {
     const chains = [...params.chains];
     let defaultChain = params.chains[0];
-    const validChainIds = Object.keys(validChains).map(Number).sort();
+    const validChainIds = Object.keys(validChains).map(Number).sort(function (a, b) { return a - b });
     for (const chainId of validChainIds) {
       const chainIndex = chains.findIndex((chain) => chain.id === chainId);
       const hasChain = chainIndex !== -1;

--- a/packages/agw-react/src/abstractWalletConnector.ts
+++ b/packages/agw-react/src/abstractWalletConnector.ts
@@ -60,7 +60,11 @@ function abstractWalletConnector(
   return (params) => {
     const chains = [...params.chains];
     let defaultChain = params.chains[0];
-    const validChainIds = Object.keys(validChains).map(Number).sort(function (a, b) { return a - b });
+    const validChainIds = Object.keys(validChains)
+      .map(Number)
+      .sort(function (a, b) {
+        return a - b;
+      });
     for (const chainId of validChainIds) {
       const chainIndex = chains.findIndex((chain) => chain.id === chainId);
       const hasChain = chainIndex !== -1;


### PR DESCRIPTION
Sorting alphabetically works well for strings ("Apple" comes before "Banana").
But, sorting numbers can produce incorrect results.
"25" is bigger than "100", because "2" is bigger than "1".

This makes abstractTestnet to become defaultChain on AGW instead of abstractMainnet when both chains are available on the dApp using AGW, which in turn can produce some issues on dApps using AGW with both Abstract testnet and mainnet.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the sorting of chain IDs to ensure that numeric values are correctly ordered, preventing issues with default chain selection in the application.

### Detailed summary
- In `packages/agw-client/src/utils.ts`, a comment about supporting Abstract mainnet was removed.
- In `packages/agw-react/src/abstractWalletConnector.ts`, the sorting of valid chain IDs was changed to ensure numeric sorting.
- A new entry in `changeset/quick-seahorses-type.md` explains the sorting issue and its impact on default chain selection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->