### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@types/node": "^22.5.5",
     "@vitest/coverage-v8": "^2.1.1",
-    "prool": "^0.0.16",
+    "pool": "^0.0.16",
     "viem": "^2.22.14",
     "vitest": "^2.1.1"
   },


### PR DESCRIPTION
Description correction:
Corrected "prool" to "pool".

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `package.json` file for the `agw-client` package by correcting a typo in the dependency name.

### Detailed summary
- Changed the dependency from `"prool": "^0.0.16"` to `"pool": "^0.0.16"` in `packages/agw-client/package.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->