### PR TITLE
fix(injectedWagmiConnector)

### DIFF
--- a/.changeset/old-bears-cover.md
+++ b/.changeset/old-bears-cover.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Fix injected wagmi connector to reconnect on reload

--- a/packages/agw-react/src/privy/injectWagmiConnector.tsx
+++ b/packages/agw-react/src/privy/injectWagmiConnector.tsx
@@ -70,7 +70,7 @@ export const InjectWagmiConnector = (props: InjectWagmiConnectorProps) => {
       return connector;
     };
 
-    if (ready && !isSetup) {
+    if (ready && (!isSetup || config.connectors.length === 0)) {
       setup(provider).then((connector) => {
         if (connector) {
           reconnect({ connectors: [connector] });
@@ -78,7 +78,7 @@ export const InjectWagmiConnector = (props: InjectWagmiConnectorProps) => {
         }
       });
     }
-  }, [provider, ready]);
+  }, [provider, ready, isSetup, config, reconnect]);
 
   return <Fragment>{children}</Fragment>;
 };


### PR DESCRIPTION
connector not connecting on router.refresh()
now useAddress() or useWriteContract() should always work

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the `InjectWagmiConnector` component in the `agw-react` package to ensure that the injected connector can reconnect properly on page reloads.

### Detailed summary
- Updated the condition in the `if` statement to check if `config.connectors.length === 0` in addition to `!isSetup`.
- Added `isSetup`, `config`, and `reconnect` to the dependency array of the `useEffect` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->