### PR TITLE
fix: Make queryClient optional on AbstractWalletProvider

### DIFF
--- a/.changeset/flat-shoes-mix.md
+++ b/.changeset/flat-shoes-mix.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+Make queryClient optional

--- a/packages/agw-react/src/agwProvider.tsx
+++ b/packages/agw-react/src/agwProvider.tsx
@@ -24,7 +24,7 @@ interface AbstractWalletConfig {
    * @type {QueryClient}
    * @default new QueryClient()
    */
-  queryClient: QueryClient;
+  queryClient?: QueryClient;
 }
 
 /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on making the `queryClient` property optional in the `agwProvider` component of the `@abstract-foundation/agw-react` package.

### Detailed summary
- Updated `queryClient` from a required property (`queryClient: QueryClient;`) to an optional property (`queryClient?: QueryClient;`) in the `agwProvider.tsx` file. 
- The default value remains `new QueryClient()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->