### PR TITLE
fix tx 0x00

### DIFF
--- a/.changeset/many-items-share.md
+++ b/.changeset/many-items-share.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Fix undefined data in transaction so it doesn't serialize to 0x00

--- a/packages/agw-client/src/actions/signTransaction.ts
+++ b/packages/agw-client/src/actions/signTransaction.ts
@@ -143,6 +143,12 @@ export async function signEip712TransactionInternal<
     customPaymasterHandler,
   );
 
+  if (transactionWithPaymaster.data === undefined) {
+    // serializer turns undefined into 0x00 which causes issues sending
+    // eth to contracts that don't have a fallback function
+    transactionWithPaymaster.data = '0x';
+  }
+
   const eip712Domain = chain?.custom.getEip712Domain({
     ...transactionWithPaymaster,
     type: 'eip712',

--- a/packages/agw-client/test/src/actions/signTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/signTransaction.test.ts
@@ -69,7 +69,6 @@ const transaction: ZksyncTransactionRequestEIP712 = {
   from: '0x0000000000000000000000000000000000000000',
   paymaster: '0x5407B5040dec3D339A9247f3654E59EEccbb6391',
   paymasterInput: '0x',
-  data: '0x',
 };
 
 const transactionWithBigIntValues = {
@@ -101,6 +100,7 @@ test('with useSignerAddress false', async () => {
       {
         chainId: anvilAbstractTestnet.chain.id,
         ...transaction,
+        data: '0x',
         from: address.smartAccountAddress,
         customSignature: signature,
         type: 'eip712' as any,
@@ -131,6 +131,7 @@ test('with useSignerAddress true', async () => {
       {
         chainId: anvilAbstractTestnet.chain.id,
         ...transaction,
+        data: '0x',
         from: address.signerAddress,
         customSignature: signature,
         type: 'eip712' as any,

--- a/packages/agw-client/test/src/actions/signTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/signTransaction.test.ts
@@ -69,6 +69,7 @@ const transaction: ZksyncTransactionRequestEIP712 = {
   from: '0x0000000000000000000000000000000000000000',
   paymaster: '0x5407B5040dec3D339A9247f3654E59EEccbb6391',
   paymasterInput: '0x',
+  data: '0x',
 };
 
 const transactionWithBigIntValues = {


### PR DESCRIPTION
- **fix(signTransaction): force undefined data to 0x so it isn't serialized to 0x00**
- **changeset**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses an issue where `undefined` data in transactions was being serialized to `0x00`, causing problems when sending ETH to contracts without a fallback function. It ensures that if `data` is `undefined`, it is set to `0x` instead.

### Detailed summary
- In `signTransaction.ts`, added a check for `transactionWithPaymaster.data` being `undefined`.
- If `data` is `undefined`, it is now set to `'0x'` to prevent serialization issues.
- Updated test cases in `signTransaction.test.ts` to reflect the change in `data` being set to `'0x'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->