### PR TITLE
 Fix Typo in AGWAccount ABI Error Name

### DIFF
--- a/packages/agw-client/src/abis/AGWAccount.ts
+++ b/packages/agw-client/src/abis/AGWAccount.ts
@@ -152,7 +152,7 @@ const AGWAccountAbi = [
   },
   {
     inputs: [],
-    name: 'RECUSIVE_MODULE_CALL',
+    name: 'RECURSIVE_MODULE_CALL',
     type: 'error',
   },
   {


### PR DESCRIPTION
## What is the purpose of the change
This pull request fixes a typo in the AGWAccount ABI by correcting the error name from "RECUSIVE_MODULE_CALL" to "RECURSIVE_MODULE_CALL". This change ensures that the error identifier is correctly spelled, which improves consistency and clarity when handling errors.

## Brief change log
- Updated the error name in `packages/agw-client/src/abis/AGWAccount.ts`:
  - **Before:** `"RECUSIVE_MODULE_CALL"`
  - **After:** `"RECURSIVE_MODULE_CALL"`

## Verifying this change
This change has been tested locally to confirm that the corrected error name is reflected throughout the application, ensuring proper error handling and debugging.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the `name` property of an error object within the `AGWAccount.ts` file.

### Detailed summary
- Changed the `name` property from `'RECUSIVE_MODULE_CALL'` to `'RECURSIVE_MODULE_CALL'` in the error object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->