### PR TITLE
Grammar Correction in Changelog

### DIFF
--- a/packages/agw-react/CHANGELOG.md
+++ b/packages/agw-react/CHANGELOG.md
@@ -77,7 +77,7 @@
 
 ### Minor Changes
 
-- 7de8115: Add non executing transaction signing
+- 7de8115: Add non-executing transaction signing
 
 ### Patch Changes
 

--- a/packages/web3-react-agw/CHANGELOG.md
+++ b/packages/web3-react-agw/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### Minor Changes
 
-- 7de8115: Add non executing transaction signing
+- 7de8115: Add non-executing transaction signing
 
 ### Patch Changes
 


### PR DESCRIPTION
Hyphenation Correction:
Old: "non executing"
New: "non-executing"
Reason: Compound adjectives should be hyphenated to improve clarity and adhere to proper English grammar rules.
