### PR TITLE
fix: optimize redundant checks and simplify code

### DIFF
--- a/packages/agw-client/src/getAgwTypedSignature.ts
+++ b/packages/agw-client/src/getAgwTypedSignature.ts
@@ -69,7 +69,7 @@ export async function getAgwTypedSignature(
 
   // if the account is already deployed, we can use signature directly
   // otherwise, we provide an ERC-6492 compatible signature
-  if (code !== undefined) {
+  if (code !== '0x') {
     return signature;
   }
 
@@ -77,8 +77,7 @@ export async function getAgwTypedSignature(
   // https://eips.ethereum.org/EIPS/eip-6492
 
   // 1. Generate the salt for account deployment
-  const addressBytes = toBytes(signer.account.address);
-  const salt = keccak256(addressBytes);
+  const salt = keccak256(signer.account.address);
 
   // 2. Generate the ERC-6492 compatible signature with deploy parameters
   return serializeErc6492Signature({


### PR DESCRIPTION
I noticed a couple of areas where the code could be improved for better clarity and efficiency:  

1. The check `if (code !== undefined)` is redundant since `getCode` always returns a string (either a contract hash or `'0x'`). I updated it to `if (code !== '0x')` to better reflect the logic.  
2. The conversion of `signer.account.address` to bytes before passing it to `keccak256` is unnecessary, as `keccak256` can handle strings directly. I simplified this to `const salt = keccak256(signer.account.address)`.  

Thanks for Abstract!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `getAgwTypedSignature.ts` file to improve the handling of account deployment signatures. It changes the condition for using a direct signature and simplifies the generation of the salt for account deployment.

### Detailed summary
- Changed the condition from checking if `code` is `undefined` to checking if `code` is `'0x'` before returning the `signature`.
- Simplified the generation of `salt` by directly passing `signer.account.address` to `keccak256` instead of converting it to bytes first.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->