### PR TITLE
chore: Prevent Undefined address in useWalletClient Calls

### DIFF
--- a/packages/agw-react/src/hooks/useGlobalWalletSignerClient.ts
+++ b/packages/agw-react/src/hooks/useGlobalWalletSignerClient.ts
@@ -11,13 +11,16 @@ import { useGlobalWalletSignerAccount } from './useGlobalWalletSignerAccount.js'
 
 export function useGlobalWalletSignerClient<
   config extends Config = ResolvedRegister['config'],
-  chainId extends
-    config['chains'][number]['id'] = config['chains'][number]['id'],
+  chainId extends config['chains'][number]['id'] = config['chains'][number]['id'],
   selectData = GetWalletClientData<config, chainId>,
 >(
   parameters: UseWalletClientParameters<config, chainId, selectData> = {},
 ): UseWalletClientReturnType<config, chainId, selectData> {
   const { address } = useGlobalWalletSignerAccount();
+
+  if (!address) {
+    throw new Error('No address found for the global wallet signer.');
+  }
 
   const walletClient = useWalletClient({
     ...parameters,


### PR DESCRIPTION
I fixed a potential issue where `address` could be `undefined` when passed to `useWalletClient`.

Now, before using `address`, the code explicitly checks its existence:  

- If `address` is missing, an error is thrown: `'No address found for the global wallet signer.'`  
- This prevents unintended behavior and improves error handling.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useGlobalWalletSignerClient` function by adding error handling to ensure that a valid wallet address is available before proceeding with the wallet client setup.

### Detailed summary
- Added a check for the `address` variable.
- If `address` is not found, an error is thrown with the message: 'No address found for the global wallet signer.'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->