### PR TITLE
fix grammar in AGW wallet description across documentation

### DIFF
--- a/packages/agw-react/README.md
+++ b/packages/agw-react/README.md
@@ -4,7 +4,7 @@ The `@abstract-foundation/agw-react` package provides React hooks and components
 
 ## Abstract Global Wallet (AGW)
 
-[Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview) is a cross-application [smart contract wallet](https://docs.abs.xyz/how-abstract-works/native-account-abstraction/smart-contract-wallets) that users can be used to interact with any application built on Abstract, powered by Abstract's [native account abstraction](https://docs.abs.xyz/how-abstract-works/native-account-abstraction).
+[Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview) is a cross-application [smart contract wallet](https://docs.abs.xyz/how-abstract-works/native-account-abstraction/smart-contract-wallets) that users can use to interact with any application built on Abstract, powered by Abstract's [native account abstraction](https://docs.abs.xyz/how-abstract-works/native-account-abstraction).
 
 
 ## Installation

--- a/packages/web3-react-agw/README.md
+++ b/packages/web3-react-agw/README.md
@@ -4,7 +4,7 @@ The `@abstract-foundation/web3-react-agw` package implements a [web3-react](http
 
 ## Abstract Global Wallet (AGW)
 
-[Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview) is a cross-application [smart contract wallet](https://docs.abs.xyz/how-abstract-works/native-account-abstraction/smart-contract-wallets) that users can be used to interact with any application built on Abstract, powered by Abstract's [native account abstraction](https://docs.abs.xyz/how-abstract-works/native-account-abstraction).
+[Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview) is a cross-application [smart contract wallet](https://docs.abs.xyz/how-abstract-works/native-account-abstraction/smart-contract-wallets) that users can use to interact with any application built on Abstract, powered by Abstract's [native account abstraction](https://docs.abs.xyz/how-abstract-works/native-account-abstraction).
 
 ## Installation
 


### PR DESCRIPTION
This PR fixes a grammatical error in the Abstract Global Wallet (AGW) description across multiple `README` files. The phrase `that users can be used to interact` has been corrected to `that users can use to interact` to improve readability and grammatical accuracy.

**Files modified:**
- `packages/web3-react-agw/README.md`
- `packages/agw-client/README.md`

The change makes the documentation more professional and easier to understand while maintaining the original meaning of the text.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting the phrasing in the `README.md` files for the `web3-react-agw` and `agw-react` packages, ensuring clarity in the description of the `Abstract Global Wallet (AGW)`.

### Detailed summary
- Changed "users can be used to interact" to "users can use to interact" in both `packages/web3-react-agw/README.md` and `packages/agw-react/README.md`.
- Added a newline at the end of `packages/agw-react/README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->