### PR TITLE
Add more tests

### DIFF
--- a/packages/agw-client/test/fixtures.ts
+++ b/packages/agw-client/test/fixtures.ts
@@ -1,5 +1,7 @@
 import {
   encodeAbiParameters,
+  maxInt256,
+  parseEther,
   toFunctionSelector,
   TypedDataDefinition,
 } from 'viem';
@@ -8,6 +10,7 @@ import {
   ConstraintCondition,
   LimitType,
   LimitUnlimited,
+  LimitZero,
   SessionConfig,
 } from '../src/sessions.js';
 
@@ -83,6 +86,28 @@ const sessionWithSimpleCallPolicy: SessionConfig = {
   transferPolicies: [],
 };
 
+const sessionWithTransferPolicy: SessionConfig = {
+  signer: sessionSignerAddress,
+  expiresAt: BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7),
+  feeLimit: {
+    limitType: LimitType.Lifetime,
+    limit: 0n,
+    period: 0n,
+  },
+  callPolicies: [],
+  transferPolicies: [
+    {
+      target: sessionTargetAddress,
+      valueLimit: {
+        limitType: LimitType.Lifetime,
+        limit: 0n,
+        period: 0n,
+      },
+      maxValuePerUse: 0n,
+    },
+  ],
+};
+
 const sessionWithUnrestrictedApprovalCallPolicy: SessionConfig = {
   signer: sessionSignerAddress,
   expiresAt: sessionExpiry,
@@ -141,6 +166,422 @@ const sessionWithConstrainedApprovalCallPolicy: SessionConfig = {
   transferPolicies: [],
 };
 
+export const sessionTests: SessionConfig[] = [
+  {
+    signer: sessionSignerAddress,
+    expiresAt: sessionExpiry,
+    feeLimit: {
+      limitType: LimitType.Lifetime,
+      limit: parseEther('1'),
+      period: BigInt(0),
+    },
+    callPolicies: [
+      {
+        target: '0xF99E6e273a90Fac72F3692B033A46e8b602DC44e',
+        selector: toFunctionSelector('burnAndMint(uint256[],uint256[])'),
+        valueLimit: LimitZero,
+        maxValuePerUse: BigInt(0),
+        constraints: [],
+      },
+      {
+        target: '0x57E12aBdF617FcD0D2ab6984C289075aA90CAc8C',
+        selector: toFunctionSelector('setApprovalForAll(address,bool)'),
+        valueLimit: LimitZero,
+        maxValuePerUse: BigInt(0),
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 0n,
+            limit: LimitUnlimited,
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              ['0xF99E6e273a90Fac72F3692B033A46e8b602DC44e'],
+            ),
+          },
+        ],
+      },
+    ],
+    transferPolicies: [],
+  },
+  {
+    signer: '0xcf1C7AcE881983CdD649881b35FC9E977453d4D6',
+    expiresAt: sessionExpiry,
+    feeLimit: {
+      limitType: 1,
+      limit: parseEther('30'),
+      period: BigInt(0),
+    },
+    callPolicies: [
+      {
+        target: '0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d',
+        selector: '0x3beba5c7',
+        valueLimit: {
+          limitType: 1,
+          limit: parseEther('30'),
+          period: BigInt(0),
+        },
+        maxValuePerUse: parseEther('30'),
+        constraints: [],
+      },
+      {
+        target: '0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d',
+        selector: '0x00f041ef',
+        valueLimit: {
+          limitType: 1,
+          limit: parseEther('30'),
+          period: BigInt(0),
+        },
+        maxValuePerUse: parseEther('30'),
+        constraints: [],
+      },
+    ],
+    transferPolicies: [],
+  },
+  {
+    signer: sessionSignerAddress,
+    expiresAt: sessionExpiry,
+    feeLimit: {
+      limitType: LimitType.Lifetime,
+      limit: parseEther('10000'),
+      period: 0n,
+    },
+    callPolicies: [
+      {
+        target: '0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1',
+        selector: toFunctionSelector('approve(address,uint256)'),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: parseEther('10000'),
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 0n,
+            limit: LimitUnlimited,
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              ['0x0b4429576e5ed44a1b8f676c8217eb45707afa3d'],
+            ),
+          },
+        ],
+      },
+      {
+        target: '0x0b4429576e5ed44a1b8f676c8217eb45707afa3d',
+        selector: toFunctionSelector('depositETH(address,uint256)'),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: parseEther('10000'),
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 0n,
+            limit: LimitUnlimited,
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              [sessionSignerAddress],
+            ),
+          },
+        ],
+      },
+      {
+        target: '0x0b4429576e5ed44a1b8f676c8217eb45707afa3d',
+        selector: toFunctionSelector('deposit(address,address,uint256)'),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: 0n,
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 1n,
+            limit: LimitUnlimited,
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              [sessionSignerAddress],
+            ),
+          },
+        ],
+      },
+      {
+        target: '0x0b4429576e5ed44a1b8f676c8217eb45707afa3d',
+        selector: toFunctionSelector('withdrawETH(uint256)'),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: 0n,
+        constraints: [],
+      },
+      {
+        target: '0x0b4429576e5ed44a1b8f676c8217eb45707afa3d',
+        selector: toFunctionSelector('withdraw(address,uint256)'),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: 0n,
+        constraints: [],
+      },
+      {
+        target: '0x0b4429576e5ed44a1b8f676c8217eb45707afa3d',
+        selector: toFunctionSelector(
+          'expire((address,address,uint32,uint64,address,uint96,address,bytes))',
+        ),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: 0n,
+        constraints: [],
+      },
+      {
+        target: '0x0b4429576e5ed44a1b8f676c8217eb45707afa3d',
+        selector: toFunctionSelector(
+          'solve((address,address,uint32,uint64,address,uint96,address,bytes),bytes32,bytes)',
+        ),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: 0n,
+        constraints: [],
+      },
+      {
+        target: '0x0b4429576e5ed44a1b8f676c8217eb45707afa3d',
+        selector: toFunctionSelector(
+          'coin((address,address,uint32,uint64,address,uint96,address,bytes),bytes,uint256)',
+        ),
+        valueLimit: LimitUnlimited,
+        maxValuePerUse: 0n,
+        constraints: [],
+      },
+    ],
+    transferPolicies: [],
+  },
+  {
+    signer: sessionSignerAddress,
+    expiresAt: sessionExpiry,
+    feeLimit: {
+      limitType: LimitType.Lifetime,
+      limit: 0n,
+      period: BigInt(0),
+    },
+    callPolicies: [
+      ...[
+        toFunctionSelector('sell(uint256,uint256,uint256,uint256)'),
+        toFunctionSelector('buy(uint256,uint256,uint256,uint256)'),
+        toFunctionSelector('claimWinnings(uint256)'),
+      ].map((selector) => ({
+        // mainnet MARKET_ERC20_CONTRACT_ADDRESS = "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC"
+        target: '0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC' as `0x${string}`, // Cast to 0x${string}
+        selector,
+        valueLimit: {
+          limitType: LimitType.Lifetime,
+          limit: 0n,
+          period: 0n,
+        },
+        maxValuePerUse: 0n,
+        constraints: [],
+      })),
+
+      {
+        target: '0xf19609e96187cdaa34cffb96473fac567e547302' as `0x${string}`, // Cast to 0x${string}
+        selector: toFunctionSelector('approve(address,uint256) external'),
+        valueLimit: {
+          limitType: LimitType.Lifetime,
+          limit: 0n,
+          period: 0n,
+        },
+        maxValuePerUse: 0n,
+        constraints: [],
+      },
+    ],
+    transferPolicies: [],
+  },
+  {
+    signer: sessionSignerAddress,
+    expiresAt: sessionExpiry,
+    feeLimit: {
+      limitType: LimitType.Lifetime,
+      limit: maxInt256,
+      period: BigInt(0),
+    },
+    callPolicies: [
+      {
+        target: '0x42b2c802205b908030Bc374c1D30Cc4997FC199a',
+        selector: toFunctionSelector('buy(address,uint256) external payable'),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: maxInt256,
+          period: BigInt(0),
+        },
+        maxValuePerUse: maxInt256,
+        constraints: [],
+      },
+      {
+        target: '0x42b2c802205b908030Bc374c1D30Cc4997FC199a',
+        selector: toFunctionSelector(
+          'sell(address,uint112,uint112) external payable',
+        ),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: maxInt256,
+          period: BigInt(0),
+        },
+        maxValuePerUse: maxInt256,
+        constraints: [],
+      },
+      {
+        target: '0x42b2c802205b908030Bc374c1D30Cc4997FC199a',
+        selector: toFunctionSelector(
+          'deployToken(address,address,string,string,uint256,string,string,bytes32) external payable',
+        ),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: maxInt256,
+          period: BigInt(0),
+        },
+        maxValuePerUse: maxInt256,
+        constraints: [],
+      },
+    ],
+    transferPolicies: [],
+  },
+  {
+    signer: sessionSignerAddress,
+    expiresAt: sessionExpiry,
+
+    feeLimit: {
+      limitType: LimitType.Lifetime,
+      limit: parseEther('30'),
+      period: 0n,
+    },
+
+    callPolicies: [
+      // allow wrapping eth
+      {
+        target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+        selector: toFunctionSelector('deposit()'),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: parseEther('30'),
+          period: 0n,
+        },
+        maxValuePerUse: parseEther('30'),
+        constraints: [],
+      },
+
+      // allow approving weth
+      {
+        target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+        selector: toFunctionSelector(
+          'function approve(address guy, uint256 wad)',
+        ),
+        valueLimit: {
+          limitType: LimitType.Lifetime,
+          limit: parseEther('30'),
+          period: 0n,
+        },
+        maxValuePerUse: parseEther('1.0'),
+        constraints: [],
+      },
+
+      // allow unwrapping eth
+      {
+        target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+        selector: toFunctionSelector('withdraw(uint256)'),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: parseEther('30'),
+          period: 0n,
+        },
+        maxValuePerUse: parseEther('30'),
+        constraints: [],
+      },
+
+      // allow purchasing tickets
+      {
+        target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
+        selector: toFunctionSelector(
+          'function purchase(uint256,uint16,address,address,uint256,uint256) external',
+        ),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: parseEther('30'),
+          period: 0n,
+        },
+        maxValuePerUse: parseEther('30'),
+        constraints: [],
+      },
+
+      // allow purchasing tickets with eth
+      {
+        target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
+        selector: toFunctionSelector(
+          'function purchaseETH(uint256,uint16,address,address,uint256,uint256) payable external',
+        ),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: parseEther('30'),
+          period: 0n,
+        },
+        maxValuePerUse: parseEther('30'),
+        constraints: [],
+      },
+
+      // allow claiming tickets
+      {
+        target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
+        selector: toFunctionSelector(
+          'function claim(uint256 poolId) external payable',
+        ),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: parseEther('30'),
+          period: 0n,
+        },
+        maxValuePerUse: parseEther('30'),
+        constraints: [],
+      },
+    ],
+
+    transferPolicies: [],
+  },
+  {
+    signer: sessionSignerAddress,
+    expiresAt: sessionExpiry,
+    feeLimit: {
+      limitType: LimitType.Lifetime,
+      limit: parseEther('1000000'),
+      period: BigInt(60 * 60 * 24),
+    },
+    callPolicies: [
+      {
+        target: '0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9',
+        selector: toFunctionSelector(
+          'requestTokenSpin(uint8, address, uint256)',
+        ),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: parseEther('1000000'),
+          period: BigInt(60 * 60 * 24),
+        },
+        maxValuePerUse: parseEther('1000000'),
+        constraints: [],
+      },
+      {
+        target: '0x9ebe3a824ca958e4b3da772d2065518f009cba62',
+        selector: toFunctionSelector('approve(address, uint256)'),
+        valueLimit: {
+          limitType: LimitType.Unlimited,
+          limit: parseEther('1000000'),
+          period: BigInt(60 * 60 * 24),
+        },
+        maxValuePerUse: parseEther('1000000'),
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 0n,
+            limit: {
+              limitType: LimitType.Unlimited,
+              limit: parseEther('1000000'),
+              period: BigInt(60 * 60 * 24),
+            },
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              ['0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9'],
+            ),
+          },
+        ],
+      },
+    ],
+    transferPolicies: [],
+  },
+];
+
 export {
   exampleTypedData,
   sessionApprovalTargetAddress,
@@ -149,5 +590,6 @@ export {
   sessionTargetAddress,
   sessionWithConstrainedApprovalCallPolicy,
   sessionWithSimpleCallPolicy,
+  sessionWithTransferPolicy,
   sessionWithUnrestrictedApprovalCallPolicy,
 };

--- a/packages/agw-client/test/fixtures.ts
+++ b/packages/agw-client/test/fixtures.ts
@@ -355,8 +355,8 @@ export const sessionTests: SessionConfig[] = [
         toFunctionSelector('buy(uint256,uint256,uint256,uint256)'),
         toFunctionSelector('claimWinnings(uint256)'),
       ].map((selector) => ({
-        target: '0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC' as `0x${string}`,
-        selector,
+        target: '0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC' as `0x${string}`, // Contract address
+        selector, // Allowed function
         valueLimit: {
           limitType: LimitType.Lifetime,
           limit: 0n,
@@ -365,9 +365,9 @@ export const sessionTests: SessionConfig[] = [
         maxValuePerUse: 0n,
         constraints: [],
       })),
-
       {
-        target: '0xf19609e96187cdaa34cffb96473fac567e547302' as `0x${string}`,
+        // PTS
+        target: '0xf19609e96187cdaa34cffb96473fac567e547302',
         selector: toFunctionSelector('approve(address,uint256) external'),
         valueLimit: {
           limitType: LimitType.Lifetime,
@@ -375,7 +375,61 @@ export const sessionTests: SessionConfig[] = [
           period: 0n,
         },
         maxValuePerUse: 0n,
-        constraints: [],
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 0n,
+            limit: LimitUnlimited,
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              ['0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC'],
+            ),
+          },
+        ],
+      },
+      {
+        // PENGU
+        target: '0x9ebe3a824ca958e4b3da772d2065518f009cba62',
+        selector: toFunctionSelector('approve(address,uint256) external'),
+        valueLimit: {
+          limitType: LimitType.Lifetime,
+          limit: 0n,
+          period: 0n,
+        },
+        maxValuePerUse: 0n,
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 0n,
+            limit: LimitUnlimited,
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              ['0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC'],
+            ),
+          },
+        ],
+      },
+      {
+        // USDC
+        target: '0x84a71ccd554cc1b02749b35d22f684cc8ec987e1',
+        selector: toFunctionSelector('approve(address,uint256) external'),
+        valueLimit: {
+          limitType: LimitType.Lifetime,
+          limit: 0n,
+          period: 0n,
+        },
+        maxValuePerUse: 0n,
+        constraints: [
+          {
+            condition: ConstraintCondition.Equal,
+            index: 0n,
+            limit: LimitUnlimited,
+            refValue: encodeAbiParameters(
+              [{ type: 'address' }],
+              ['0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC'],
+            ),
+          },
+        ],
       },
     ],
     transferPolicies: [],
@@ -429,106 +483,106 @@ export const sessionTests: SessionConfig[] = [
     ],
     transferPolicies: [],
   },
-  {
-    signer: sessionSignerAddress,
-    expiresAt: sessionExpiry,
+  // {
+  //   signer: sessionSignerAddress,
+  //   expiresAt: sessionExpiry,
 
-    feeLimit: {
-      limitType: LimitType.Lifetime,
-      limit: parseEther('30'),
-      period: 0n,
-    },
+  //   feeLimit: {
+  //     limitType: LimitType.Lifetime,
+  //     limit: parseEther('30'),
+  //     period: 0n,
+  //   },
 
-    callPolicies: [
-      // allow wrapping eth
-      {
-        target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
-        selector: toFunctionSelector('deposit()'),
-        valueLimit: {
-          limitType: LimitType.Unlimited,
-          limit: parseEther('30'),
-          period: 0n,
-        },
-        maxValuePerUse: parseEther('30'),
-        constraints: [],
-      },
+  //   callPolicies: [
+  //     // allow wrapping eth
+  //     {
+  //       target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+  //       selector: toFunctionSelector('deposit()'),
+  //       valueLimit: {
+  //         limitType: LimitType.Unlimited,
+  //         limit: parseEther('30'),
+  //         period: 0n,
+  //       },
+  //       maxValuePerUse: parseEther('30'),
+  //       constraints: [],
+  //     },
 
-      // allow approving weth
-      {
-        target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
-        selector: toFunctionSelector(
-          'function approve(address guy, uint256 wad)',
-        ),
-        valueLimit: {
-          limitType: LimitType.Lifetime,
-          limit: parseEther('30'),
-          period: 0n,
-        },
-        maxValuePerUse: parseEther('1.0'),
-        constraints: [],
-      },
+  //     // allow approving weth
+  //     {
+  //       target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+  //       selector: toFunctionSelector(
+  //         'function approve(address guy, uint256 wad)',
+  //       ),
+  //       valueLimit: {
+  //         limitType: LimitType.Lifetime,
+  //         limit: parseEther('30'),
+  //         period: 0n,
+  //       },
+  //       maxValuePerUse: parseEther('1.0'),
+  //       constraints: [],
+  //     },
 
-      // allow unwrapping eth
-      {
-        target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
-        selector: toFunctionSelector('withdraw(uint256)'),
-        valueLimit: {
-          limitType: LimitType.Unlimited,
-          limit: parseEther('30'),
-          period: 0n,
-        },
-        maxValuePerUse: parseEther('30'),
-        constraints: [],
-      },
+  //     // allow unwrapping eth
+  //     {
+  //       target: '0x3439153EB7AF838Ad19d56E1571FBD09333C2809',
+  //       selector: toFunctionSelector('withdraw(uint256)'),
+  //       valueLimit: {
+  //         limitType: LimitType.Unlimited,
+  //         limit: parseEther('30'),
+  //         period: 0n,
+  //       },
+  //       maxValuePerUse: parseEther('30'),
+  //       constraints: [],
+  //     },
 
-      // allow purchasing tickets
-      {
-        target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
-        selector: toFunctionSelector(
-          'function purchase(uint256,uint16,address,address,uint256,uint256) external',
-        ),
-        valueLimit: {
-          limitType: LimitType.Unlimited,
-          limit: parseEther('30'),
-          period: 0n,
-        },
-        maxValuePerUse: parseEther('30'),
-        constraints: [],
-      },
+  //     // allow purchasing tickets
+  //     {
+  //       target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
+  //       selector: toFunctionSelector(
+  //         'function purchase(uint256,uint16,address,address,uint256,uint256) external',
+  //       ),
+  //       valueLimit: {
+  //         limitType: LimitType.Unlimited,
+  //         limit: parseEther('30'),
+  //         period: 0n,
+  //       },
+  //       maxValuePerUse: parseEther('30'),
+  //       constraints: [],
+  //     },
 
-      // allow purchasing tickets with eth
-      {
-        target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
-        selector: toFunctionSelector(
-          'function purchaseETH(uint256,uint16,address,address,uint256,uint256) payable external',
-        ),
-        valueLimit: {
-          limitType: LimitType.Unlimited,
-          limit: parseEther('30'),
-          period: 0n,
-        },
-        maxValuePerUse: parseEther('30'),
-        constraints: [],
-      },
+  //     // allow purchasing tickets with eth
+  //     {
+  //       target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
+  //       selector: toFunctionSelector(
+  //         'function purchaseETH(uint256,uint16,address,address,uint256,uint256) payable external',
+  //       ),
+  //       valueLimit: {
+  //         limitType: LimitType.Unlimited,
+  //         limit: parseEther('30'),
+  //         period: 0n,
+  //       },
+  //       maxValuePerUse: parseEther('30'),
+  //       constraints: [],
+  //     },
 
-      // allow claiming tickets
-      {
-        target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
-        selector: toFunctionSelector(
-          'function claim(uint256 poolId) external payable',
-        ),
-        valueLimit: {
-          limitType: LimitType.Unlimited,
-          limit: parseEther('30'),
-          period: 0n,
-        },
-        maxValuePerUse: parseEther('30'),
-        constraints: [],
-      },
-    ],
+  //     // allow claiming tickets
+  //     {
+  //       target: '0x3272596F776470D2D7C3f7dfF3dc50888b7D8967',
+  //       selector: toFunctionSelector(
+  //         'function claim(uint256 poolId) external payable',
+  //       ),
+  //       valueLimit: {
+  //         limitType: LimitType.Unlimited,
+  //         limit: parseEther('30'),
+  //         period: 0n,
+  //       },
+  //       maxValuePerUse: parseEther('30'),
+  //       constraints: [],
+  //     },
+  //   ],
 
-    transferPolicies: [],
-  },
+  //   transferPolicies: [],
+  // },
   {
     signer: sessionSignerAddress,
     expiresAt: sessionExpiry,

--- a/packages/agw-client/test/fixtures.ts
+++ b/packages/agw-client/test/fixtures.ts
@@ -355,8 +355,7 @@ export const sessionTests: SessionConfig[] = [
         toFunctionSelector('buy(uint256,uint256,uint256,uint256)'),
         toFunctionSelector('claimWinnings(uint256)'),
       ].map((selector) => ({
-        // mainnet MARKET_ERC20_CONTRACT_ADDRESS = "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC"
-        target: '0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC' as `0x${string}`, // Cast to 0x${string}
+        target: '0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC' as `0x${string}`,
         selector,
         valueLimit: {
           limitType: LimitType.Lifetime,
@@ -368,7 +367,7 @@ export const sessionTests: SessionConfig[] = [
       })),
 
       {
-        target: '0xf19609e96187cdaa34cffb96473fac567e547302' as `0x${string}`, // Cast to 0x${string}
+        target: '0xf19609e96187cdaa34cffb96473fac567e547302' as `0x${string}`,
         selector: toFunctionSelector('approve(address,uint256) external'),
         valueLimit: {
           limitType: LimitType.Lifetime,

--- a/packages/agw-client/test/fixtures.ts
+++ b/packages/agw-client/test/fixtures.ts
@@ -166,7 +166,7 @@ const sessionWithConstrainedApprovalCallPolicy: SessionConfig = {
   transferPolicies: [],
 };
 
-export const sessionTests: SessionConfig[] = [
+export const sampleSessionConfigs: SessionConfig[] = [
   {
     signer: sessionSignerAddress,
     expiresAt: sessionExpiry,

--- a/packages/agw-client/test/src/sessionValidator.test.ts
+++ b/packages/agw-client/test/src/sessionValidator.test.ts
@@ -152,11 +152,10 @@ describe('assertSessionKeyPolicies', async () => {
     });
   });
 
-  // Test for early return when no session can be parsed (lines 55-56)
   it('should return early when no session can be parsed from the transaction', async () => {
     const transaction = {
       to: '0x1234567890123456789012345678901234567890' as Address,
-      data: '0x12345678' as Hex, // Cast to Hex type
+      data: '0x12345678' as Hex,
     };
 
     // Reset the multicall mock to track if it gets called
@@ -175,7 +174,7 @@ describe('assertSessionKeyPolicies', async () => {
     expect(client.multicall).not.toHaveBeenCalled();
   });
 
-  // Test for transfer policies validation (lines 112-121)
+  // Test for transfer policies validation
   it('should validate transfer policies correctly', async () => {
     const transaction = {
       to: SESSION_KEY_VALIDATOR_ADDRESS as Address,
@@ -215,7 +214,6 @@ describe('assertSessionKeyPolicies', async () => {
     );
   });
 
-  // Test for when policy status is not allowed (lines 135-139)
   it('should throw when policy status is not allowed', async () => {
     const transaction = {
       to: SESSION_KEY_VALIDATOR_ADDRESS as Address,
@@ -242,7 +240,6 @@ describe('assertSessionKeyPolicies', async () => {
   });
 
   it('should validate all predefined session configurations', async () => {
-    // Import the sessionTests array
     const { sessionTests } = await import('../fixtures.js');
 
     for (const sessionConfig of sessionTests) {
@@ -283,10 +280,8 @@ describe('assertSessionKeyPolicies', async () => {
   });
 
   it('should detect policy violations in session configurations', async () => {
-    // Import the sessionTests array
     const { sessionTests } = await import('../fixtures.js');
 
-    // Just test the first session config for simplicity
     const sessionConfig = sessionTests[0];
 
     const transaction = {
@@ -298,17 +293,14 @@ describe('assertSessionKeyPolicies', async () => {
       }),
     };
 
-    // Mock the policy status to be denied for this test
     getCallPolicy.mockReturnValue(
       encodedPolicyStatus[SessionKeyPolicyStatus.Denied],
     );
 
-    // Mock multicall to return a denied status
     client.multicall = vi
       .fn()
       .mockResolvedValue([SessionKeyPolicyStatus.Denied.toString()]);
 
-    // Test that the session validation throws an error
     await expect(
       assertSessionKeyPolicies(
         client,
@@ -320,7 +312,6 @@ describe('assertSessionKeyPolicies', async () => {
   });
 
   it('should detect mixed policy statuses correctly', async () => {
-    // Import the sessionTests array
     const { sessionTests } = await import('../fixtures.js');
 
     // Find a session with multiple policies

--- a/packages/agw-client/test/src/sessionValidator.test.ts
+++ b/packages/agw-client/test/src/sessionValidator.test.ts
@@ -240,9 +240,9 @@ describe('assertSessionKeyPolicies', async () => {
   });
 
   it('should validate all predefined session configurations', async () => {
-    const { sessionTests } = await import('../fixtures.js');
+    const { sampleSessionConfigs } = await import('../fixtures.js');
 
-    for (const sessionConfig of sessionTests) {
+    for (const sessionConfig of sampleSessionConfigs) {
       const transaction = {
         to: SESSION_KEY_VALIDATOR_ADDRESS as Address,
         data: encodeFunctionData({
@@ -280,9 +280,9 @@ describe('assertSessionKeyPolicies', async () => {
   });
 
   it('should detect policy violations in session configurations', async () => {
-    const { sessionTests } = await import('../fixtures.js');
+    const { sampleSessionConfigs } = await import('../fixtures.js');
 
-    const sessionConfig = sessionTests[0];
+    const sessionConfig = sampleSessionConfigs[0];
 
     const transaction = {
       to: SESSION_KEY_VALIDATOR_ADDRESS as Address,
@@ -312,14 +312,14 @@ describe('assertSessionKeyPolicies', async () => {
   });
 
   it('should detect mixed policy statuses correctly', async () => {
-    const { sessionTests } = await import('../fixtures.js');
+    const { sampleSessionConfigs } = await import('../fixtures.js');
 
     // Find a session with multiple policies
     const sessionConfig =
-      sessionTests.find(
+      sampleSessionConfigs.find(
         (s) =>
           (s.callPolicies?.length || 0) + (s.transferPolicies?.length || 0) > 1,
-      ) || sessionTests[0];
+      ) || sampleSessionConfigs[0];
 
     const transaction = {
       to: SESSION_KEY_VALIDATOR_ADDRESS as Address,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the session key policy validation tests by adding new test cases for transfer policies and updating the session configuration fixtures to include a `sessionWithTransferPolicy`.

### Detailed summary
- Added `sessionWithTransferPolicy` to `fixtures.ts`.
- Introduced multiple test cases in `sessionValidator.test.ts` for:
  - Early return when no session can be parsed.
  - Validating transfer policies.
  - Throwing an error for denied policy status.
  - Validating all predefined session configurations.
  - Detecting policy violations in session configurations.
  - Handling mixed policy statuses correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->