### PR TITLE
fix: incorrect type parameter declaration

### DIFF
--- a/packages/agw-client/src/actions/signTypedData.ts
+++ b/packages/agw-client/src/actions/signTypedData.ts
@@ -90,7 +90,7 @@ export async function signTypedData(
 }
 
 export async function signTypedDataForSession<
-  const typedData extends TypedData | Record<string, unknown>,
+  typedData extends TypedData | Record<string, unknown>,
   primaryType extends string,
 >(
   client: Client<Transport, ChainEIP712, Account>,


### PR DESCRIPTION
In a function's generic declaration, the keyword `const` cannot be used before the type parameter name. This results in a syntax error.
Removed const keyword from the generic parameter typedData

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the type definition of the `signTypedDataForSession` function in the `signTypedData.ts` file to remove the `const` keyword from the generic parameter `typedData`.

### Detailed summary
- Removed `const` keyword from the generic parameter `typedData` in the `signTypedDataForSession` function definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->