### PR TITLE
Fix .rejects in asynchronous tests

### DIFF
--- a/packages/agw-client/test/src/actions/signTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/signTransaction.test.ts
@@ -200,7 +200,7 @@ test('invalid chain', async () => {
       } as SignEip712TransactionParameters,
       EOA_VALIDATOR_ADDRESS,
       false,
-    )
+    ),
   ).rejects.toThrowError('Invalid chain specified');
 });
 
@@ -217,7 +217,8 @@ test('no account provided', async () => {
       } as any,
       EOA_VALIDATOR_ADDRESS,
       false,
-    )
-  ).rejects.toThrowError('Could not find an Account to execute with this Action.');
+    ),
+  ).rejects.toThrowError(
+    'Could not find an Account to execute with this Action.',
+  );
 });
-

--- a/packages/agw-client/test/src/actions/signTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/signTransaction.test.ts
@@ -188,39 +188,36 @@ test('handles hex values', async () => {
 
 test('invalid chain', async () => {
   const invalidChain = mainnet;
-  expect(
-    async () =>
-      await signTransaction(
-        baseClient,
-        signerClient,
-        {
-          ...transaction,
-          type: 'eip712',
-          account: baseClient.account,
-          chain: invalidChain,
-        } as SignEip712TransactionParameters,
-        EOA_VALIDATOR_ADDRESS,
-        false,
-      ),
+  await expect(
+    signTransaction(
+      baseClient,
+      signerClient,
+      {
+        ...transaction,
+        type: 'eip712',
+        account: baseClient.account,
+        chain: invalidChain,
+      } as SignEip712TransactionParameters,
+      EOA_VALIDATOR_ADDRESS,
+      false,
+    )
   ).rejects.toThrowError('Invalid chain specified');
 });
 
 test('no account provided', async () => {
   baseClient.account = undefined as any;
-  expect(
-    async () =>
-      await signTransaction(
-        baseClient,
-        signerClient,
-        {
-          ...transaction,
-          type: 'eip712',
-          chain: anvilAbstractTestnet.chain as ChainEIP712,
-        } as any,
-        EOA_VALIDATOR_ADDRESS,
-        false,
-      ),
-  ).rejects.toThrowError(
-    'Could not find an Account to execute with this Action.',
-  );
+  await expect(
+    signTransaction(
+      baseClient,
+      signerClient,
+      {
+        ...transaction,
+        type: 'eip712',
+        chain: anvilAbstractTestnet.chain as ChainEIP712,
+      } as any,
+      EOA_VALIDATOR_ADDRESS,
+      false,
+    )
+  ).rejects.toThrowError('Could not find an Account to execute with this Action.');
 });
+


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `signTransaction` function tests by updating the assertions to use `await expect(...).rejects.toThrowError(...)` for better readability and clarity when checking for specific error messages.

### Detailed summary
- Updated the `invalid chain` test to use `await expect(...).rejects.toThrowError('Invalid chain specified')`.
- Modified the `no account provided` test to use `await expect(...).rejects.toThrowError('Could not find an Account to execute with this Action.')`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->