### PR TITLE
Fix duplicate module mocking error

### DIFF
--- a/packages/agw-client/test/src/actions/writeContractForSession.test.ts
+++ b/packages/agw-client/test/src/actions/writeContractForSession.test.ts
@@ -21,12 +21,6 @@ vi.mock('../../../src/actions/sendTransactionForSession', () => ({
     .mockResolvedValue('0xmockedTransactionHash'),
 }));
 
-vi.mock('../../../src/actions/sendTransactionForSession', () => ({
-  sendTransactionForSession: vi
-    .fn()
-    .mockResolvedValue('0xmockedTransactionHash'),
-}));
-
 import { sendTransactionForSession } from '../../../src/actions/sendTransactionForSession.js';
 import { writeContractForSession } from '../../../src/actions/writeContractForSession.js';
 import { LimitType, SessionConfig } from '../../../src/sessions.js';


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the mock implementation of `sendTransactionForSession` in the test file `writeContractForSession.test.ts`, which may indicate a shift towards using the actual implementation in tests.

### Detailed summary
- Removed the mock for `sendTransactionForSession` in `writeContractForSession.test.ts`.
- The import statements for `sendTransactionForSession`, `writeContractForSession`, `LimitType`, and `SessionConfig` remain unchanged.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->