### PR TITLE
fix: generic parameter inconsistency

### DIFF
--- a/packages/agw-react/src/query/createSession.ts
+++ b/packages/agw-react/src/query/createSession.ts
@@ -182,7 +182,7 @@ export type CreateSessionMutateAsync<
     | MutateOptions<
         CreateSessionData,
         WriteContractErrorType,
-        CreateSessionVariables<config, config['chains'][number]['id']>,
+        CreateSessionVariables<config, chainId>,
         context
       >
     | undefined,


### PR DESCRIPTION
<!-- start pr-codex -->
The `CreateSessionMutateAsync` type uses an inconsistent generic parameter. This inconsistency may cause typing to consider all possible values of `chainId` rather than the specific value passed in the function call, which reduces typing safety.

## PR-Codex overview
This PR focuses on updating the type definition in the `createSession.ts` file to improve type safety by using `chainId` instead of a more complex type expression.

### Detailed summary
- Changed the type from `CreateSessionVariables<config, config['chains'][number]['id']>` to `CreateSessionVariables<config, chainId>` for clarity and simplicity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->