### PR TITLE
chore: remove feature flag check for session validation

### DIFF
--- a/.changeset/lovely-bobcats-judge.md
+++ b/.changeset/lovely-bobcats-judge.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+chore: remove feature flag check

--- a/packages/agw-client/src/sessionValidator.ts
+++ b/packages/agw-client/src/sessionValidator.ts
@@ -49,16 +49,6 @@ export async function assertSessionKeyPolicies<
     return;
   }
 
-  const enableValidation = await isFeatureFlagEnabled(
-    client,
-    account.address,
-    'session-key-validator',
-  );
-
-  if (!enableValidation) {
-    return;
-  }
-
   const session = getSessionFromTransaction(account, transaction);
 
   if (!session) {

--- a/packages/agw-client/src/sessionValidator.ts
+++ b/packages/agw-client/src/sessionValidator.ts
@@ -16,7 +16,6 @@ import {
   SESSION_KEY_VALIDATOR_ADDRESS,
 } from './constants.js';
 import { AGWAccountAbi } from './exports/constants.js';
-import { isFeatureFlagEnabled } from './featureFlagRegistry.js';
 import { ConstraintCondition, getSessionSpec } from './sessions.js';
 
 const restrictedSelectors = new Set<string>([

--- a/packages/agw-client/test/src/sessionValidator.test.ts
+++ b/packages/agw-client/test/src/sessionValidator.test.ts
@@ -245,32 +245,6 @@ describe('assertSessionKeyPolicies', async () => {
     ).rejects.toThrow('Session key policy violation');
   });
 
-  it('should not validate when feature flag is disabled', async () => {
-    const transaction = {
-      to: SESSION_KEY_VALIDATOR_ADDRESS as Address,
-      data: encodeFunctionData({
-        abi: SessionKeyValidatorAbi,
-        functionName: 'createSession',
-        args: [sessionWithTransferPolicy],
-      }),
-    };
-
-    client.readContract = vi.fn().mockResolvedValue(false);
-    // Mock multicall to return a non-allowed status
-    client.multicall = vi
-      .fn()
-      .mockResolvedValue([SessionKeyPolicyStatus.Denied.toString()]) as any;
-
-    await expect(
-      assertSessionKeyPolicies(
-        client,
-        anvilAbstractMainnet.chain.id,
-        parseAccount(address.smartAccountAddress),
-        transaction,
-      ),
-    ).resolves.not.toThrow();
-  });
-
   it('should validate all predefined session configurations', async () => {
     const { sampleSessionConfigs } = await import('../fixtures.js');
 


### PR DESCRIPTION
- **chore: remove feature flag check**
- **changeset**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing a feature flag check from the `sessionValidator.ts` file and the associated test in `sessionValidator.test.ts`, simplifying the session key validation process.

### Detailed summary
- Removed the import of `isFeatureFlagEnabled` from `featureFlagRegistry.js`.
- Eliminated the feature flag check that determined whether to validate session keys in `assertSessionKeyPolicies`.
- Deleted the test case that checked validation behavior when the feature flag was disabled.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->