### PR TITLE
Fix duplicate disconnect handler & add missing `await` in `activate`

### DIFF
--- a/packages/web3-react-agw/src/index.ts
+++ b/packages/web3-react-agw/src/index.ts
@@ -63,11 +63,6 @@ export class AbstractGlobalWallet extends Connector {
             this.onError?.(error);
           });
 
-          this.provider.on('disconnect', (error: ProviderRpcError): void => {
-            this.actions.resetState();
-            this.onError?.(error);
-          });
-
           this.provider.on('chainChanged', (chainId: string): void => {
             this.actions.update({ chainId: parseChainId(chainId) });
           });
@@ -148,7 +143,7 @@ export class AbstractGlobalWallet extends Connector {
           method: 'wallet_switchEthereumChain',
           params: [{ chainId: desiredChainIdHex }],
         });
-        this.activate(desiredChainId);
+        await this.activate(desiredChainId);
       } else {
         throw new Error('Invalid chain');
       }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling and ensuring proper activation of the Ethereum wallet by modifying event listeners and updating method calls within the `AbstractGlobalWallet` class.

### Detailed summary
- Removed the event listener for `disconnect` which resets state and handles errors.
- Changed the call to `this.activate(desiredChainId)` to `await this.activate(desiredChainId)` for proper asynchronous handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->