### PR TITLE
fix: memoize wagmi config

### DIFF
--- a/.changeset/healthy-worms-jump.md
+++ b/.changeset/healthy-worms-jump.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-react': patch
+---
+
+fix: Memoize wagmi config in AbstractWalletProvider

--- a/packages/agw-react/src/agwProvider.tsx
+++ b/packages/agw-react/src/agwProvider.tsx
@@ -3,7 +3,7 @@ import {
   validChains,
 } from '@abstract-foundation/agw-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { type Chain, http, type Transport } from 'viem';
 import { createConfig, WagmiProvider } from 'wagmi';
 
@@ -66,19 +66,21 @@ export const AbstractWalletProvider = ({
     throw new Error(`Chain ${chain.id} is not supported`);
   }
 
-  const wagmiConfig = createConfig({
-    chains: [chain],
-    ssr: true,
-    connectors: [
-      abstractWalletConnector({
-        customPaymasterHandler,
-      }),
-    ],
-    transports: {
-      [chain.id]: transport ?? http(),
-    },
-    multiInjectedProviderDiscovery: false,
-  });
+  const wagmiConfig = useMemo(() => {
+    return createConfig({
+      chains: [chain],
+      ssr: true,
+      connectors: [
+        abstractWalletConnector({
+          customPaymasterHandler,
+        }),
+      ],
+      transports: {
+        [chain.id]: transport ?? http(),
+      },
+      multiInjectedProviderDiscovery: false,
+    });
+  }, [chain, transport, customPaymasterHandler]);
 
   return (
     <WagmiProvider config={wagmiConfig}>


### PR DESCRIPTION
Fixes #268

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the `wagmi` configuration in the `AbstractWalletProvider` component by memoizing the configuration to prevent unnecessary re-renders.

### Detailed summary
- Changed the import statement to include `useMemo` from `react`.
- Wrapped the `wagmiConfig` creation in `useMemo` to optimize performance.
- The dependencies for `useMemo` include `chain`, `transport`, and `customPaymasterHandler`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->