### PR TITLE
Update tsconfig.base.json

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,7 +28,7 @@
     // Language and environment
     "moduleResolution": "Node",
     "module": "ES2020",
-    "target": "ES2021", // Setting this to `ES2021` enables native support for `Node v16+`: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping.
+    "target": "ES2021", // Setting this to `ES2021` enables native support for `Node v16+`: https://github.com/microsoft/TypeScript/wiki/.
     "lib": [
       "ES2022",
       "DOM" // We are adding `DOM` here to get the `fetch`, etc. types. This should be removed once these types are available via DefinitelyTyped.


### PR DESCRIPTION
change old link to a new one 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `tsconfig.base.json` file, specifically modifying the `target` property and adjusting the comment related to TypeScript's `Node` target mapping.

### Detailed summary
- Changed the `target` from `ES2021` to `ES2021` (no functional change).
- Updated the comment associated with the `target` to remove the specific mention of `Node v16+` and the link to the TypeScript wiki.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->