### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/agw-client-coverage.yml
+++ b/.github/workflows/agw-client-coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/agw-client-test.yml
+++ b/.github/workflows/agw-client-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflows to use `actions/checkout@v4` instead of `actions/checkout@v3`, enhancing the checkout functionality across multiple workflow files.

### Detailed summary
- Updated `.github/workflows/agw-client-test.yml` to use `actions/checkout@v4`.
- Updated `.github/workflows/agw-client-coverage.yml` to use `actions/checkout@v4`.
- Updated `.github/workflows/release.yml` to use `actions/checkout@v4`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->