### PR TITLE
perf: remove deployment check on sendTransactionForSession

### DIFF
--- a/.changeset/khaki-ligers-develop.md
+++ b/.changeset/khaki-ligers-develop.md
@@ -1,0 +1,7 @@
+---
+'@abstract-foundation/web3-react-agw': patch
+'@abstract-foundation/agw-client': patch
+'@abstract-foundation/agw-react': patch
+---
+
+perf: remove reundant rpc call when sending transactions for sessions

--- a/packages/agw-client/src/actions/sendTransactionForSession.ts
+++ b/packages/agw-client/src/actions/sendTransactionForSession.ts
@@ -21,7 +21,6 @@ import {
   type SessionConfig,
 } from '../sessions.js';
 import type { CustomPaymasterHandler } from '../types/customPaymaster.js';
-import { isSmartAccountDeployed } from '../utils.js';
 import { sendTransactionInternal } from './sendTransactionInternal.js';
 
 export interface SendTransactionForSessionParameters<
@@ -63,14 +62,6 @@ export async function sendTransactionForSession<
   session: SessionConfig,
   customPaymasterHandler: CustomPaymasterHandler | undefined = undefined,
 ): Promise<SendEip712TransactionReturnType> {
-  const isDeployed = await isSmartAccountDeployed(
-    publicClient,
-    client.account.address,
-  );
-  if (!isDeployed) {
-    throw new BaseError('Smart account not deployed');
-  }
-
   const selector: Hex | undefined = parameters.data
     ? `0x${parameters.data.slice(2, 10)}`
     : undefined;

--- a/packages/agw-client/test/src/actions/sendTransactionForSession.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransactionForSession.test.ts
@@ -208,24 +208,6 @@ describe('sendTransaction', () => {
     );
   });
 
-  it('should call throw if AGW is not deployed', async () => {
-    vi.mocked(isSmartAccountDeployed).mockResolvedValue(false);
-    await expect(
-      sendTransactionForSession(
-        baseClient,
-        signerClient,
-        publicClient,
-        {
-          ...transaction1,
-          type: 'eip712',
-          account: baseClient.account,
-          chain: anvilAbstractTestnet.chain as ChainEIP712,
-        },
-        session,
-      ),
-    ).rejects.toThrow('Smart account not deployed');
-  });
-
   it('should call throw if to field is not set', async () => {
     vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
     await expect(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on optimizing the `sendTransactionForSession` function by removing a redundant RPC call that checks if a smart account is deployed, thereby improving performance.

### Detailed summary
- Removed the check for whether the smart account is deployed in `sendTransactionForSession`.
- Deleted the corresponding test case that expected an error when the smart account is not deployed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->