### PR TITLE
Update pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1494,7 +1494,7 @@ packages:
 
   '@motionone/vue@10.16.4':
     resolution: {integrity: sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==}
-    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion
+    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://motion.oku-ui.com/
 
   '@noble/ciphers@1.2.1':
     resolution: {integrity: sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==}


### PR DESCRIPTION
https://oku-ui.com/motion - does not work ( 404 )

https://motion.oku-ui.com/ - is correct

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `pnpm-lock.yaml` file by modifying the deprecation message for `@motionone/vue` and includes a resolution for `@noble/ciphers`. 

### Detailed summary
- Updated deprecation message for `@motionone/vue` to point to `https://motion.oku-ui.com/` instead of `https://oku-ui.com/motion`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->