### PR TITLE
feat: add signTransactionBatch method for raw signing

### DIFF
--- a/.changeset/hungry-worms-guess.md
+++ b/.changeset/hungry-worms-guess.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+Add signTransactionBatch method for raw signing of batch transactions

--- a/packages/agw-client/src/actions/sendPrivyTransaction.ts
+++ b/packages/agw-client/src/actions/sendPrivyTransaction.ts
@@ -17,7 +17,7 @@ import {
 
 import { replaceBigInts } from '../replaceBigInts.js';
 import type { SendTransactionBatchParameters } from '../types/sendTransactionBatch.js';
-
+import type { SignTransactionBatchParameters } from '../types/signTransactionBatch.js';
 export async function sendPrivyTransaction<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
   account extends Account | undefined = Account | undefined,
@@ -79,7 +79,9 @@ export async function signPrivyTransaction<
   chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
 >(
   client: Client<Transport, ChainEIP712, Account>,
-  parameters: SignEip712TransactionParameters<chain, account, chainOverride>,
+  parameters:
+    | SignEip712TransactionParameters<chain, account, chainOverride>
+    | SignTransactionBatchParameters<chain, account, chainOverride>,
 ): Promise<SignEip712TransactionReturnType> {
   const { chain: _chain, account: _account, ...request } = parameters;
 

--- a/packages/agw-client/src/actions/signTransactionBatch.ts
+++ b/packages/agw-client/src/actions/signTransactionBatch.ts
@@ -26,14 +26,14 @@ import { signTransaction } from './signTransaction.js';
  * import { useAbstractClient } from "@abstract-foundation/agw-react";
  * import { encodeFunctionData, parseUnits } from "viem";
  *
- * export default function SendTransactionBatch() {
+ * export default function SignTransactionBatch() {
  *   const { data: agwClient } = useAbstractClient();
  *
- *   async function sendTransactionBatch() {
+ *   async function signTransactionBatch() {
  *     if (!agwClient) return;
  *
- *     // Batch multiple transactions in a single call
- *     const hash = await agwClient.sendTransactionBatch({
+ *     // Sign a batch of multiple transactions in a single call
+ *     const rawTransaction = await agwClient.signTransactionBatch({
  *       calls: [
  *         // 1. Simple ETH transfer
  *         {
@@ -63,25 +63,16 @@ import { signTransaction } from './signTransaction.js';
  *       ]
  *     });
  *
- *     console.log("Transaction hash:", hash);
+ *     console.log("Serialized transaction:", rawTransaction);
  *   }
  * }
  * ```
  *
- * @param parameters - Parameters for sending a batch of transactions
+ * @param parameters - Parameters for signing a batch of transactions
  * @param parameters.calls - An array of transaction requests. Each transaction can include:
  *   - to: The recipient address (required)
- *   - from: The sender address (defaults to the AGW address)
  *   - data: Contract code or method call with encoded args
- *   - gas: Gas provided for execution
- *   - nonce: Unique transaction identifier
  *   - value: Amount in wei to send
- *   - maxFeePerGas: Total fee per gas
- *   - maxPriorityFeePerGas: Priority fee per gas
- *   - gasPerPubdata: Gas per byte of data
- *   - factoryDeps: Bytecodes of contract dependencies
- *   - customSignature: Custom transaction signature
- *   - type: Transaction type
  * @param parameters.paymaster - Address of the paymaster smart contract that will pay the gas fees
  * @param parameters.paymasterInput - Input data to the paymaster
  * @returns The transaction hash of the submitted transaction batch

--- a/packages/agw-client/src/types/signTransactionBatch.ts
+++ b/packages/agw-client/src/types/signTransactionBatch.ts
@@ -1,0 +1,15 @@
+import type { GetChainParameter } from 'viem';
+import type { Account, Address, Hex } from 'viem';
+import type { GetAccountParameter } from 'viem/_types/types/account';
+import type { ChainEIP712, SignEip712TransactionParameters } from 'viem/zksync';
+
+export type SignTransactionBatchParameters<
+  chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+  account extends Account | undefined = Account | undefined,
+  chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
+> = {
+  calls: SignEip712TransactionParameters<chain, account, chainOverride>[];
+  paymaster?: Address | undefined;
+  paymasterInput?: Hex | undefined;
+} & GetAccountParameter<account, Account | Address, true, true> &
+  GetChainParameter<chain, chainOverride>;

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -27,6 +27,7 @@ import {
   type Eip712WalletActions,
   type SendEip712TransactionParameters,
   type SignEip712TransactionParameters,
+  type SignEip712TransactionReturnType,
 } from 'viem/zksync';
 
 import { type AbstractClient } from './abstractClient.js';
@@ -69,6 +70,7 @@ import { sendTransactionBatch } from './actions/sendTransactionBatch.js';
 import { sendTransactionForSession } from './actions/sendTransactionForSession.js';
 import { signMessage } from './actions/signMessage.js';
 import { signTransaction } from './actions/signTransaction.js';
+import { signTransactionBatch } from './actions/signTransactionBatch.js';
 import { signTransactionForSession } from './actions/signTransactionForSession.js';
 import {
   signTypedData,
@@ -81,6 +83,7 @@ import { type SessionClient, toSessionClient } from './sessionClient.js';
 import type { SessionConfig, SessionStatus } from './sessions.js';
 import type { CustomPaymasterHandler } from './types/customPaymaster.js';
 import type { SendTransactionBatchParameters } from './types/sendTransactionBatch.js';
+import type { SignTransactionBatchParameters } from './types/signTransactionBatch.js';
 
 export type AbstractWalletActions<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
@@ -108,6 +111,9 @@ export type AbstractWalletActions<
   >(
     args: SendTransactionBatchParameters<request>,
   ) => Promise<SendTransactionReturnType>;
+  signTransactionBatch: (
+    args: SignTransactionBatchParameters<chain, account>,
+  ) => Promise<SignEip712TransactionReturnType>;
   prepareAbstractTransactionRequest: <
     chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
     account extends Account | undefined = Account | undefined,
@@ -281,6 +287,17 @@ export function globalWalletActions<
         signerClient,
         publicClient,
         args as SignEip712TransactionParameters<chain, account>,
+        EOA_VALIDATOR_ADDRESS,
+        {},
+        customPaymasterHandler,
+        isPrivyCrossApp,
+      ),
+    signTransactionBatch: (args) =>
+      signTransactionBatch(
+        client,
+        signerClient,
+        publicClient,
+        args as SignTransactionBatchParameters<chain, account>,
         EOA_VALIDATOR_ADDRESS,
         {},
         customPaymasterHandler,

--- a/packages/agw-client/test/src/actions/signTransactionBatch.test.ts
+++ b/packages/agw-client/test/src/actions/signTransactionBatch.test.ts
@@ -1,0 +1,104 @@
+import {
+  Address,
+  createClient,
+  createPublicClient,
+  createWalletClient,
+  EIP1193RequestFn,
+  encodeAbiParameters,
+  Hex,
+  http,
+  parseAbiParameters,
+  toFunctionSelector,
+} from 'viem';
+import { toAccount } from 'viem/accounts';
+import {
+  ChainEIP712,
+  parseEip712Transaction,
+  ZksyncTransactionRequestEIP712,
+} from 'viem/zksync';
+import { describe, expect, test, vi } from 'vitest';
+
+import { signTransactionBatch } from '../../../src/actions/signTransactionBatch.js';
+import { EOA_VALIDATOR_ADDRESS } from '../../../src/constants.js';
+import { anvilAbstractTestnet } from '../../anvil.js';
+import { address } from '../../constants.js';
+const RAW_SIGNATURE =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+const publicClient = createPublicClient({
+  chain: anvilAbstractTestnet.chain as ChainEIP712,
+  transport: anvilAbstractTestnet.clientConfig.transport,
+});
+
+const baseClient = createClient({
+  account: address.smartAccountAddress,
+  chain: anvilAbstractTestnet.chain as ChainEIP712,
+  transport: anvilAbstractTestnet.clientConfig.transport,
+});
+
+baseClient.request = (async ({ method, params }) => {
+  if (method === 'eth_chainId') {
+    return anvilAbstractTestnet.chain.id;
+  } else if (method === 'eth_call') {
+    const callParams = params as {
+      to: Address;
+      data: Hex;
+    };
+    if (
+      callParams.to === address.smartAccountAddress &&
+      callParams.data.startsWith(toFunctionSelector('function listHooks(bool)'))
+    ) {
+      return encodeAbiParameters(parseAbiParameters(['address[]']), [[]]);
+    }
+    return encodeAbiParameters(parseAbiParameters(['address[]']), [[]]);
+  }
+  return anvilAbstractTestnet.getClient().request({ method, params } as any);
+}) as EIP1193RequestFn;
+
+const signerClient = createWalletClient({
+  account: toAccount(address.signerAddress),
+  chain: anvilAbstractTestnet.chain as ChainEIP712,
+  transport: http(baseClient.transport.url),
+});
+
+signerClient.request = (async ({ method, params }) => {
+  if (method === 'eth_signTypedData_v4') {
+    return RAW_SIGNATURE;
+  }
+  return anvilAbstractTestnet.getClient().request({ method, params } as any);
+}) as EIP1193RequestFn;
+
+describe('signTransactionBatch', () => {
+  test('signs a batch of EIP-712 transactions correctly', async () => {
+    const transactions: ZksyncTransactionRequestEIP712[] = [
+      {
+        to: '0xAbc1230000000000000000000000000000000000',
+        value: 1n,
+      },
+      {
+        to: '0xDEF4560000000000000000000000000000000000',
+        value: 2n,
+        data: '0xabababab',
+      },
+    ];
+
+    const signedBatch = await signTransactionBatch(
+      baseClient,
+      signerClient,
+      publicClient,
+      {
+        calls: transactions,
+      },
+      EOA_VALIDATOR_ADDRESS,
+    );
+
+    const parsedBatch = parseEip712Transaction(signedBatch);
+
+    expect(parsedBatch.type).toBe('eip712');
+    expect(parsedBatch.to).toBe(baseClient.account.address);
+    expect(parsedBatch.data?.slice(0, 10)).toBe(
+      toFunctionSelector('function batchCall((address,bool,uint256,bytes)[])'),
+    );
+    expect(parsedBatch.value).toBe(3n);
+  });
+});

--- a/packages/agw-client/test/src/walletActions.test.ts
+++ b/packages/agw-client/test/src/walletActions.test.ts
@@ -7,6 +7,7 @@ import * as sendTransactionModule from '../../src/actions/sendTransaction.js';
 import * as sendTransactionBatchModule from '../../src/actions/sendTransactionBatch.js';
 import * as sendTransactionForSessionModule from '../../src/actions/sendTransactionForSession.js';
 import * as signTransactionModule from '../../src/actions/signTransaction.js';
+import * as signTransactionBatchModule from '../../src/actions/signTransactionBatch.js';
 import * as writeContractModule from '../../src/actions/writeContract.js';
 import * as writeContractForSessionModule from '../../src/actions/writeContractForSession.js';
 import { EOA_VALIDATOR_ADDRESS } from '../../src/constants.js';
@@ -26,7 +27,7 @@ vi.mock('../../src/actions/prepareTransaction');
 vi.mock('../../src/actions/writeContractForSession');
 vi.mock('../../src/actions/sendTransactionForSession');
 vi.mock('../../src/actions/sendTransactionBatch');
-
+vi.mock('../../src/actions/signTransactionBatch');
 describe('globalWalletActions', () => {
   const mockSignerClient = {
     account: {
@@ -71,7 +72,7 @@ describe('globalWalletActions', () => {
 
   it('should call sendTransactionBatch with correct arguments', async () => {
     const mockArgs = {
-      requests: [
+      calls: [
         { to: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826', value: 100n },
       ],
     };
@@ -95,6 +96,27 @@ describe('globalWalletActions', () => {
     };
     await actions.signTransaction(mockArgs as any);
     expect(signTransactionModule.signTransaction).toHaveBeenCalledWith(
+      mockClient,
+      mockSignerClient,
+      mockPublicClient,
+      mockArgs,
+      EOA_VALIDATOR_ADDRESS,
+      {},
+      undefined,
+      false,
+    );
+  });
+
+  it('should call signTransactionBatch with correct arguments', async () => {
+    const mockArgs = {
+      calls: [
+        { to: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826', value: 100n },
+      ],
+    };
+    await actions.signTransactionBatch(mockArgs as any);
+    expect(
+      signTransactionBatchModule.signTransactionBatch,
+    ).toHaveBeenCalledWith(
       mockClient,
       mockSignerClient,
       mockPublicClient,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `signTransactionBatch` method for signing multiple transactions in a single call within the `@abstract-foundation/agw-client` package. It enhances transaction handling capabilities and integrates new types for batch processing.

### Detailed summary
- Added `signTransactionBatch` method in `packages/agw-client/src/actions/signTransactionBatch.ts`.
- Defined `SignTransactionBatchParameters` type in `packages/agw-client/src/types/signTransactionBatch.ts`.
- Updated `sendPrivyTransaction` to accept `SignTransactionBatchParameters`.
- Modified `getBatchTransactionObject` to handle both `SendTransactionBatchParameters` and `SignTransactionBatchParameters`.
- Updated tests in `packages/agw-client/test/src/actions/signTransactionBatch.test.ts` to validate the new method.
- Integrated `signTransactionBatch` into `globalWalletActions` in `packages/agw-client/src/walletActions.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->