### PR TITLE
feat: do not show secondary confirmation dialog after sending a transaction

### DIFF
--- a/.changeset/chilly-phones-knock.md
+++ b/.changeset/chilly-phones-knock.md
@@ -1,0 +1,7 @@
+---
+'@abstract-foundation/web3-react-agw': minor
+'@abstract-foundation/agw-client': minor
+'@abstract-foundation/agw-react': minor
+---
+
+feat: use privy sign instead of send transaction to bypass confirmation window

--- a/packages/agw-client/src/actions/sendTransactionBatch.ts
+++ b/packages/agw-client/src/actions/sendTransactionBatch.ts
@@ -157,7 +157,7 @@ export async function sendTransactionBatch<
     throw new Error('No calls provided');
   }
   if (isPrivyCrossApp) {
-    const signedTx = await signPrivyTransaction(client, parameters as any); // TODO: fix this
+    const signedTx = await signPrivyTransaction(client, parameters as any);
     return await publicClient.sendRawTransaction({
       serializedTransaction: signedTx,
     });

--- a/packages/agw-client/src/actions/sendTransactionBatch.ts
+++ b/packages/agw-client/src/actions/sendTransactionBatch.ts
@@ -17,7 +17,7 @@ import { type Call } from '../types/call.js';
 import type { CustomPaymasterHandler } from '../types/customPaymaster.js';
 import type { SendTransactionBatchParameters } from '../types/sendTransactionBatch.js';
 import type { SignTransactionBatchParameters } from '../types/signTransactionBatch.js';
-import { sendPrivyTransaction } from './sendPrivyTransaction.js';
+import { signPrivyTransaction } from './sendPrivyTransaction.js';
 import { sendTransactionInternal } from './sendTransactionInternal.js';
 
 export function getBatchTransactionObject<
@@ -157,7 +157,10 @@ export async function sendTransactionBatch<
     throw new Error('No calls provided');
   }
   if (isPrivyCrossApp) {
-    return await sendPrivyTransaction(client, parameters);
+    const signedTx = await signPrivyTransaction(client, parameters as any); // TODO: fix this
+    return await publicClient.sendRawTransaction({
+      serializedTransaction: signedTx,
+    });
   }
 
   const batchTransaction = getBatchTransactionObject(

--- a/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
@@ -17,10 +17,7 @@ import { address } from '../../../constants.js';
 vi.mock('../../../../src/actions/sendTransactionInternal');
 vi.mock('../../../../src/actions/sendPrivyTransaction');
 
-import {
-  sendPrivyTransaction,
-  signPrivyTransaction,
-} from '../../../../src/actions/sendPrivyTransaction.js';
+import { signPrivyTransaction } from '../../../../src/actions/sendPrivyTransaction.js';
 import { sendTransactionInternal } from '../../../../src/actions/sendTransactionInternal.js';
 
 // Client setup

--- a/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransaction/sendTransaction.test.ts
@@ -17,7 +17,10 @@ import { address } from '../../../constants.js';
 vi.mock('../../../../src/actions/sendTransactionInternal');
 vi.mock('../../../../src/actions/sendPrivyTransaction');
 
-import { sendPrivyTransaction } from '../../../../src/actions/sendPrivyTransaction.js';
+import {
+  sendPrivyTransaction,
+  signPrivyTransaction,
+} from '../../../../src/actions/sendPrivyTransaction.js';
 import { sendTransactionInternal } from '../../../../src/actions/sendTransactionInternal.js';
 
 // Client setup
@@ -86,7 +89,9 @@ describe('sendTransaction', () => {
   });
 
   test('sendTransaction calls sendPrivyTransaction correctly', async () => {
-    vi.mocked(sendPrivyTransaction).mockResolvedValue('0x01234');
+    vi.mocked(signPrivyTransaction).mockResolvedValue('0x01abab');
+    vi.spyOn(publicClient, 'sendRawTransaction').mockResolvedValue('0x01234');
+
     const transactionHash = await sendTransaction(
       baseClient,
       signerClient,
@@ -98,10 +103,13 @@ describe('sendTransaction', () => {
       true,
     );
 
-    expect(sendPrivyTransaction).toHaveBeenCalledWith(
+    expect(signPrivyTransaction).toHaveBeenCalledWith(
       baseClient,
       expect.objectContaining(transaction),
     );
+    expect(publicClient.sendRawTransaction).toHaveBeenCalledWith({
+      serializedTransaction: '0x01abab',
+    });
     expect(transactionHash).toBe('0x01234');
   });
 });

--- a/packages/agw-client/test/src/actions/sendTransaction/sendTransactionBatch.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransaction/sendTransactionBatch.test.ts
@@ -30,7 +30,10 @@ vi.mock('../../../../src/actions/sendTransactionInternal');
 vi.mock('../../../../src/actions/sendPrivyTransaction');
 
 import AGWAccountAbi from '../../../../src/abis/AGWAccount.js';
-import { sendPrivyTransaction } from '../../../../src/actions/sendPrivyTransaction.js';
+import {
+  sendPrivyTransaction,
+  signPrivyTransaction,
+} from '../../../../src/actions/sendPrivyTransaction.js';
 import { sendTransactionInternal } from '../../../../src/actions/sendTransactionInternal.js';
 
 // Client setup
@@ -238,7 +241,8 @@ describe('sendTransactionBatch', () => {
 
 describe('sendTransactionBatch with isPrivyCrossApp', () => {
   it('should call sendPrivyTransaction', async () => {
-    vi.mocked(sendPrivyTransaction).mockResolvedValue('0x01234');
+    vi.mocked(signPrivyTransaction).mockResolvedValue('0x01abab');
+    vi.spyOn(publicClient, 'sendRawTransaction').mockResolvedValue('0x01234');
 
     const transactionHash = await sendTransactionBatch(
       baseClient,
@@ -251,9 +255,13 @@ describe('sendTransactionBatch with isPrivyCrossApp', () => {
       true,
     );
 
-    expect(sendPrivyTransaction).toHaveBeenCalledWith(baseClient, {
+    expect(signPrivyTransaction).toHaveBeenCalledWith(baseClient, {
       paymaster: '0x5407B5040dec3D339A9247f3654E59EEccbb6391',
       calls: [transaction1, transaction2],
+    });
+
+    expect(publicClient.sendRawTransaction).toHaveBeenCalledWith({
+      serializedTransaction: '0x01abab',
     });
 
     expect(transactionHash).toBe('0x01234');

--- a/packages/agw-client/test/src/actions/signTransactionBatch.test.ts
+++ b/packages/agw-client/test/src/actions/signTransactionBatch.test.ts
@@ -70,7 +70,7 @@ signerClient.request = (async ({ method, params }) => {
 
 describe('signTransactionBatch', () => {
   test('signs a batch of EIP-712 transactions correctly', async () => {
-    const transactions: ZksyncTransactionRequestEIP712[] = [
+    const transactions = [
       {
         to: '0xAbc1230000000000000000000000000000000000',
         value: 1n,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on replacing the `sendPrivyTransaction` function with `signPrivyTransaction` to streamline transaction signing and bypass the confirmation window in the `sendTransactionBatch` process.

### Detailed summary
- Updated `signTransactionBatch` test to reflect changes in transaction signing.
- Replaced `sendPrivyTransaction` with `signPrivyTransaction` in `sendTransactionBatch` implementation.
- Modified relevant tests to mock and assert `signPrivyTransaction`.
- Enhanced error handling for insufficient balance scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->