### PR TITLE
chore(ci): bump pnpm/action-setup to v4 for Node 22 support

### DIFF
--- a/.github/workflows/agw-client-coverage.yml
+++ b/.github/workflows/agw-client-coverage.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '22'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 

--- a/.github/workflows/agw-client-test.yml
+++ b/.github/workflows/agw-client-test.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '22'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 


### PR DESCRIPTION
I ditched `pnpm/action-setup@v2` for v4 because v2 breaks on Node 22. Only CI files changed—runs should turn green.








<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `pnpm/action-setup` action from `v2` to `v4` in two workflow files, improving dependency management in the CI process.

### Detailed summary
- In `.github/workflows/agw-client-test.yml`:
  - Updated `pnpm/action-setup` from `v2` to `v4`.
- In `.github/workflows/agw-client-coverage.yml`:
  - Updated `pnpm/action-setup` from `v2` to `v4`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->