### PR TITLE
chore(ci): remove pnpm version spec from workflows

### DIFF
--- a/.github/workflows/agw-client-coverage.yml
+++ b/.github/workflows/agw-client-coverage.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/agw-client-test.yml
+++ b/.github/workflows/agw-client-test.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Set up foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.4.0
 
       - name: Set up node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.4.0
 
       - name: Set up node
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the setup for `pnpm` in multiple GitHub workflow files, ensuring consistency in the version used across different workflows.

### Detailed summary
- Removed `version: 9.4.0` from `pnpm/action-setup@v4` in:
  - `.github/workflows/release.yml`
  - `.github/workflows/publish-npm-packages.yml`
- Updated `version` for `pnpm/action-setup@v4` to `9` in:
  - `.github/workflows/agw-client-test.yml`
  - `.github/workflows/agw-client-coverage.yml`
- Kept `foundry-rs/foundry-toolchain@v1` setup in `.github/workflows/agw-client-test.yml` and `.github/workflows/agw-client-coverage.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->