### PR TITLE
add: insufficient balance check

### DIFF
--- a/.changeset/blue-meals-listen.md
+++ b/.changeset/blue-meals-listen.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+feat: Throw insufficient balance error if the user's balance can not cover the transaction cost + gas

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -334,15 +334,19 @@ export async function prepareTransactionRequest<
   const asyncOperations = [];
   let userBalance: bigint | undefined;
 
-  // Get balance if the transaction is not sponsored
-
-  asyncOperations.push(
-    getBalance(publicClient, {
-      address: initiatorAccount.address,
-    }).then((balance: bigint) => {
-      userBalance = balance;
-    }),
-  );
+  // Get balance if the transaction is not sponsored or has a value
+  if (
+    !args.isSponsored ||
+    (request.value !== undefined && request.value > 0n)
+  ) {
+    asyncOperations.push(
+      getBalance(publicClient, {
+        address: initiatorAccount.address,
+      }).then((balance: bigint) => {
+        userBalance = balance;
+      }),
+    );
+  }
 
   // Get nonce if needed
   if (

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -286,7 +286,7 @@ export async function prepareTransactionRequest<
     chainOverride,
     accountOverride,
     request
-  > & { isSponsored?: boolean },
+  >,
 ): Promise<PrepareTransactionRequestReturnType> {
   const { gas, nonce, parameters: parameterNames = defaultParameters } = args;
 

--- a/packages/agw-client/src/actions/sendTransactionInternal.ts
+++ b/packages/agw-client/src/actions/sendTransactionInternal.ts
@@ -69,6 +69,9 @@ export async function sendTransactionInternal<
       {
         ...parameters,
         parameters: ['gas', 'nonce', 'fees'],
+        isSponsored:
+          customPaymasterHandler !== undefined ||
+          (parameters as any).paymaster !== undefined,
       } as any,
     );
 

--- a/packages/agw-client/test/src/actions/prepareTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/prepareTransaction.test.ts
@@ -335,3 +335,154 @@ test('throws if insufficient balance', async () => {
     ),
   ).rejects.toThrow(InsufficientBalanceError);
 });
+
+test('does not throw if balance is sufficient with value', async () => {
+  vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
+
+  // Create a modified public client that returns a very low balance
+  const publicClientWithLowBalance = createPublicClient({
+    chain: anvilAbstractTestnet.chain as ChainEIP712,
+    transport: anvilAbstractTestnet.clientConfig.transport,
+  });
+
+  publicClientWithLowBalance.request = (async ({ method, params }) => {
+    if (method === 'zks_estimateFee') {
+      return {
+        gas_limit: 100_000n,
+        gas_per_pubdata_limit: '0x143b',
+        max_fee_per_gas: toHex(MOCK_FEE_PER_GAS),
+        max_priority_fee_per_gas: '0x0',
+      };
+    } else if (method === 'eth_getBalance') {
+      return parseEther('0.09');
+    }
+    return anvilAbstractTestnet.getClient().request({ method, params } as any);
+  }) as EIP1193RequestFn;
+
+  await expect(
+    prepareTransactionRequest(
+      baseClient,
+      signerClient,
+      publicClientWithLowBalance,
+      {
+        ...transaction,
+        value: parseEther('0.001'),
+        chain: anvilAbstractTestnet.chain,
+        isInitialTransaction: false,
+      },
+    ),
+  ).resolves.not.toThrow();
+});
+
+test('does not throw if balance is sufficient with no value', async () => {
+  vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
+
+  // Create a modified public client that returns a very low balance
+  const publicClientWithLowBalance = createPublicClient({
+    chain: anvilAbstractTestnet.chain as ChainEIP712,
+    transport: anvilAbstractTestnet.clientConfig.transport,
+  });
+
+  publicClientWithLowBalance.request = (async ({ method, params }) => {
+    if (method === 'zks_estimateFee') {
+      return {
+        gas_limit: 100_000n,
+        gas_per_pubdata_limit: '0x143b',
+        max_fee_per_gas: toHex(MOCK_FEE_PER_GAS),
+        max_priority_fee_per_gas: '0x0',
+      };
+    } else if (method === 'eth_getBalance') {
+      return parseEther('0.09');
+    }
+    return anvilAbstractTestnet.getClient().request({ method, params } as any);
+  }) as EIP1193RequestFn;
+
+  await expect(
+    prepareTransactionRequest(
+      baseClient,
+      signerClient,
+      publicClientWithLowBalance,
+      {
+        ...transaction,
+        chain: anvilAbstractTestnet.chain,
+        isInitialTransaction: false,
+      },
+    ),
+  ).resolves.not.toThrow();
+});
+
+test('throws if balance is insufficient with no value', async () => {
+  vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
+
+  // Create a modified public client that returns a very low balance
+  const publicClientWithLowBalance = createPublicClient({
+    chain: anvilAbstractTestnet.chain as ChainEIP712,
+    transport: anvilAbstractTestnet.clientConfig.transport,
+  });
+
+  publicClientWithLowBalance.request = (async ({ method, params }) => {
+    if (method === 'zks_estimateFee') {
+      return {
+        gas_limit: 100_000n,
+        gas_per_pubdata_limit: '0x143b',
+        max_fee_per_gas: toHex(MOCK_FEE_PER_GAS),
+        max_priority_fee_per_gas: '0x0',
+      };
+    } else if (method === 'eth_getBalance') {
+      return 25000000100000n - 1n; //1 wei short
+    }
+    return anvilAbstractTestnet.getClient().request({ method, params } as any);
+  }) as EIP1193RequestFn;
+
+  await expect(
+    prepareTransactionRequest(
+      baseClient,
+      signerClient,
+      publicClientWithLowBalance,
+      {
+        ...transaction,
+        chain: anvilAbstractTestnet.chain,
+        isInitialTransaction: false,
+      },
+    ),
+  ).rejects.toThrow(InsufficientBalanceError);
+});
+
+test('does not throw if insufficient balance if the transaction is sponsored', async () => {
+  vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
+
+  // Create a modified public client that returns a very low balance
+  const publicClientWithLowBalance = createPublicClient({
+    chain: anvilAbstractTestnet.chain as ChainEIP712,
+    transport: anvilAbstractTestnet.clientConfig.transport,
+  });
+
+  publicClientWithLowBalance.request = (async ({ method, params }) => {
+    if (method === 'zks_estimateFee') {
+      return {
+        gas_limit: 100_000n,
+        gas_per_pubdata_limit: '0x143b',
+        max_fee_per_gas: toHex(MOCK_FEE_PER_GAS),
+        max_priority_fee_per_gas: '0x0',
+      };
+    } else if (method === 'eth_getBalance') {
+      return parseEther('0.09');
+    }
+    return anvilAbstractTestnet.getClient().request({ method, params } as any);
+  }) as EIP1193RequestFn;
+
+  await expect(
+    prepareTransactionRequest(
+      baseClient,
+      signerClient,
+      publicClientWithLowBalance,
+      {
+        ...transaction,
+        value: parseEther('0.1'),
+        chain: anvilAbstractTestnet.chain,
+        isInitialTransaction: false,
+        isSponsored: true,
+      },
+    ),
+  ).resolves.not.toThrow();
+});


### PR DESCRIPTION
We can check if a request will fail with insufficient balance at the SDK level rather than wait for it to fail during tx simulation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces error handling for insufficient user balance when processing transactions, ensuring that users are notified if their balance cannot cover the transaction cost and gas fees. 

### Detailed summary
- Added `InsufficientBalanceError` for balance checks.
- Introduced `isSponsored` flag in transaction requests.
- Implemented balance retrieval logic in `prepareTransactionRequest`.
- Added checks for sufficient balance against transaction value and gas costs.
- Enhanced tests to cover various balance scenarios, including sponsored transactions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->