### PR TITLE
add transformHexValues to prepareTransaction

### DIFF
--- a/.changeset/serious-penguins-help.md
+++ b/.changeset/serious-penguins-help.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+fix: add call to transformHexValues in prepareTransaction

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -62,7 +62,7 @@ import {
 import { InsufficientBalanceError } from '../errors/insufficientBalance.js';
 import { AccountFactoryAbi } from '../exports/constants.js';
 import type { Call } from '../types/call.js';
-import { isSmartAccountDeployed } from '../utils.js';
+import { isSmartAccountDeployed, transformHexValues } from '../utils.js';
 import { getInitializerCalldata } from '../utils.js';
 
 export type IsUndefined<T> = [undefined] extends [T] ? true : false;
@@ -288,6 +288,17 @@ export async function prepareTransactionRequest<
     request
   >,
 ): Promise<PrepareTransactionRequestReturnType> {
+  // transform values in case any are provided in hex format (from rpc)
+  transformHexValues(args, [
+    'value',
+    'nonce',
+    'maxFeePerGas',
+    'maxPriorityFeePerGas',
+    'gas',
+    'chainId',
+    'gasPerPubdata',
+  ]);
+
   const { gas, nonce, parameters: parameterNames = defaultParameters } = args;
 
   const isDeployed = await isSmartAccountDeployed(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `prepareTransaction` function by integrating a call to `transformHexValues`, which processes input values that may be in hexadecimal format.

### Detailed summary
- Added a call to `transformHexValues` in the `prepareTransactionRequest` function.
- Included `transformHexValues` in the import statement from `../utils.js`.
- Specified the fields to be transformed: `value`, `nonce`, `maxFeePerGas`, `maxPriorityFeePerGas`, `gas`, `chainId`, `gasPerPubdata`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->