### PR TITLE
fix atomic capability

### DIFF
--- a/.changeset/breezy-knives-destroy.md
+++ b/.changeset/breezy-knives-destroy.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+fix: atomic capability spec mismatch

--- a/packages/agw-client/src/eip5792.ts
+++ b/packages/agw-client/src/eip5792.ts
@@ -17,7 +17,7 @@ interface AtomicCapabilityV1 {
 }
 
 interface AtomicCapabilityV2 {
-  supported: 'supported' | 'ready' | 'unsupported';
+  status: 'supported' | 'ready' | 'unsupported';
 }
 
 interface ChainCapabilitiesV1 {
@@ -65,12 +65,12 @@ export interface SendCallsParamsV2 {
 export const agwCapabilitiesV2: WalletCapabilitiesV2 = {
   '0xab5': {
     atomic: {
-      supported: 'supported',
+      status: 'supported',
     },
   },
   '0x2b74': {
     atomic: {
-      supported: 'supported',
+      status: 'supported',
     },
   },
 };


### PR DESCRIPTION
- **capabilities should return atomic.status not atomic.supported**
- **changeset**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `AtomicCapabilityV2` interface and its usage in the `agwCapabilitiesV2` object to replace the `supported` property with `status`, improving clarity in the code.

### Detailed summary
- Changed the property name from `supported` to `status` in the `AtomicCapabilityV2` interface.
- Updated the `agwCapabilitiesV2` object to reflect the change from `supported` to `status` for atomic capabilities in both instances (`0xab5` and `0x2b74`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->