### PR TITLE
fix: compute sponsorship status inside prepareTransactionRequest

### DIFF
--- a/.changeset/red-foxes-cough.md
+++ b/.changeset/red-foxes-cough.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+fix: compute tx sponsorship status inside prepareTransactionRequest

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -141,11 +141,6 @@ export type PrepareTransactionRequestRequest<
      * Whether the transaction is the first transaction of the account.
      */
     isInitialTransaction?: boolean;
-
-    /**
-     * Whether the transaction is sponsored.
-     */
-    isSponsored?: boolean;
   };
 
 export type PrepareTransactionRequestParameters<
@@ -299,6 +294,17 @@ export async function prepareTransactionRequest<
     'gasPerPubdata',
   ]);
 
+  const isSponsored =
+    'paymaster' in args &&
+    'paymasterInput' in args &&
+    args.paymaster !== undefined &&
+    args.paymasterInput !== undefined;
+
+  if (isSponsored) {
+    console.log(args);
+  }
+
+  console.log('isSponsored', isSponsored);
   const { gas, nonce, parameters: parameterNames = defaultParameters } = args;
 
   const isDeployed = await isSmartAccountDeployed(
@@ -346,10 +352,7 @@ export async function prepareTransactionRequest<
   let userBalance: bigint | undefined;
 
   // Get balance if the transaction is not sponsored or has a value
-  if (
-    !args.isSponsored ||
-    (request.value !== undefined && request.value > 0n)
-  ) {
+  if (!isSponsored || (request.value !== undefined && request.value > 0n)) {
     asyncOperations.push(
       getBalance(publicClient, {
         address: initiatorAccount.address,
@@ -443,7 +446,7 @@ export async function prepareTransactionRequest<
 
   // Check if user has enough balance
   const gasCost =
-    args.isSponsored || !request.gas || !request.maxFeePerGas
+    isSponsored || !request.gas || !request.maxFeePerGas
       ? 0n
       : request.gas * request.maxFeePerGas;
 

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -300,11 +300,6 @@ export async function prepareTransactionRequest<
     args.paymaster !== undefined &&
     args.paymasterInput !== undefined;
 
-  if (isSponsored) {
-    console.log(args);
-  }
-
-  console.log('isSponsored', isSponsored);
   const { gas, nonce, parameters: parameterNames = defaultParameters } = args;
 
   const isDeployed = await isSmartAccountDeployed(

--- a/packages/agw-client/test/src/actions/prepareTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/prepareTransaction.test.ts
@@ -363,16 +363,29 @@ test.each([
     return anvilAbstractTestnet.getClient().request({ method, params } as any);
   }) as EIP1193RequestFn;
 
+  const txWithoutPaymaster = {
+    ...transaction,
+    ...(value !== undefined && { value }),
+    paymaster: undefined,
+    paymasterInput: undefined,
+  };
+
+  const paymasterArgs = isSponsored
+    ? {
+        paymaster: transaction.paymaster,
+        paymasterInput: transaction.paymasterInput,
+      }
+    : {};
+
   const txRequest = prepareTransactionRequest(
     baseClient,
     signerClient,
     publicClientWithCustomBalance,
     {
-      ...transaction,
-      ...(value !== undefined && { value }),
+      ...txWithoutPaymaster,
+      ...paymasterArgs,
       chain: anvilAbstractTestnet.chain,
       isInitialTransaction: false,
-      ...(isSponsored && { isSponsored }),
     },
   );
 


### PR DESCRIPTION
- **compute issponsored inside prepare tx**
- **changeset**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the transaction sponsorship handling within the `prepareTransactionRequest` function in the `agw-client` package. It refines how the transaction request is prepared by eliminating the `isSponsored` parameter and introducing a more robust check for sponsorship.

### Detailed summary
- Updated `prepareTransactionRequest` to compute sponsorship status internally.
- Removed the `isSponsored` parameter from the request parameters.
- Introduced `isSponsored` variable to determine sponsorship based on `paymaster` and `paymasterInput`.
- Adjusted conditions for checking user balance based on the new sponsorship logic.
- Updated gas cost calculation to use the new sponsorship check.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->