### PR TITLE
fix errors reundant to redundant in CHANGELOG.md

### DIFF
--- a/packages/agw-client/CHANGELOG.md
+++ b/packages/agw-client/CHANGELOG.md
@@ -56,7 +56,7 @@
 
 ### Patch Changes
 
-- 764642c: perf: remove reundant rpc call when sending transactions for sessions
+- 764642c: perf: remove redundant rpc call when sending transactions for sessions
 
 ## 1.6.2
 

--- a/packages/agw-react/CHANGELOG.md
+++ b/packages/agw-react/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### Patch Changes
 
-- 764642c: perf: remove reundant rpc call when sending transactions for sessions
+- 764642c: perf: remove redundant rpc call when sending transactions for sessions
 - Updated dependencies [764642c]
   - @abstract-foundation/agw-client@1.6.3
 

--- a/packages/web3-react-agw/CHANGELOG.md
+++ b/packages/web3-react-agw/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### Patch Changes
 
-- 764642c: perf: remove reundant rpc call when sending transactions for sessions
+- 764642c: perf: remove redundant rpc call when sending transactions for sessions
 - Updated dependencies [764642c]
   - @abstract-foundation/agw-client@1.6.3
 


### PR DESCRIPTION
`reundant` - `redundant` x3

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the changelog entries across multiple packages, ensuring consistency in the description of performance improvements related to RPC calls when sending transactions for sessions.

### Detailed summary
- Fixed typo from "reundant" to "redundant" in the `CHANGELOG.md` files for:
  - `agw-client`
  - `agw-react`
  - `web3-react-agw`
- Updated dependencies for `agw-react` and `web3-react-agw` to `@abstract-foundation/agw-client@1.6.3`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->