### PR TITLE
fix: wallet_getcallsstatus should not return null item in array for pending tx

### DIFF
--- a/.changeset/curvy-dolls-fail.md
+++ b/.changeset/curvy-dolls-fail.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+fix(EIP-5792): don't return null receipt in wallet_getCallsStatus

--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -297,7 +297,8 @@ export function transformEIP1193Provider(
           id: params[0],
           chainId: toHex(chain.id),
           status: getReceiptStatus(receipt ?? undefined),
-          receipts: [receipt],
+          atomic: true, // AGW will always process multiple calls as an atomic batch
+          receipts: receipt != null ? [receipt] : undefined,
         };
       }
       case 'wallet_addEthereumChain':

--- a/packages/agw-client/test/src/transformEIP1193Provider.test.ts
+++ b/packages/agw-client/test/src/transformEIP1193Provider.test.ts
@@ -800,5 +800,35 @@ describe('transformEIP1193Provider', () => {
         params: [mockTxHash],
       });
     });
+    it('should return undefined receipts on wallet_getCallsStatus for null eth_getTransactionReceipt result', async () => {
+      const mockTxHash = '0xtxhash';
+
+      const originalMock = mockProvider.request as Mock;
+      originalMock.mockImplementation((request) => {
+        if (request.method === 'eth_getTransactionReceipt') {
+          return Promise.resolve(null);
+        }
+        return originalMock.getMockImplementation()?.(request);
+      });
+
+      const result = await transformedProvider.request({
+        method: 'wallet_getCallsStatus',
+        params: [mockTxHash],
+      });
+
+      expect(result).toStrictEqual({
+        version: '2.0.0',
+        id: mockTxHash,
+        chainId: toHex(abstractTestnet.id),
+        status: 100,
+        atomic: true,
+        receipts: undefined,
+      });
+
+      expect(mockProvider.request).toHaveBeenCalledWith({
+        method: 'eth_getTransactionReceipt',
+        params: [mockTxHash],
+      });
+    });
   });
 });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the behavior of the `wallet_getCallsStatus` method in the `agw-client` package by ensuring it does not return a null receipt when the underlying `eth_getTransactionReceipt` call returns null.

### Detailed summary
- Updated the `wallet_getCallsStatus` method to return `undefined` for receipts if `eth_getTransactionReceipt` returns null.
- Added a test case to verify the behavior of `wallet_getCallsStatus` when receiving a null result from `eth_getTransactionReceipt`.
- Ensured the `receipts` field in the response is conditionally set based on the receipt value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->