### PR TITLE
ci: create workflow for publishing private packages

### DIFF
--- a/.github/workflows/publish-npm-packages-private.yml
+++ b/.github/workflows/publish-npm-packages-private.yml
@@ -1,0 +1,36 @@
+name: Publish Packages (Private)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          cache: 'pnpm'
+          scope: '@abstract-foundation'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Publish packages
+        run: pnpm -r publish --no-git-checks --access restricted --tag 'experimental'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a GitHub Actions workflow for publishing private NPM packages. It sets up the environment, installs dependencies, builds the packages, and publishes them to a specified registry.

### Detailed summary
- Added a new workflow file: `.github/workflows/publish-npm-packages-private.yml`
- Defined a workflow named `Publish Packages (Private)` triggered by `workflow_dispatch`
- Configured a job `publish` to run on `ubuntu-latest`
- Set permissions for reading contents and writing packages
- Included steps for:
  - Checking out the repository
  - Setting up `pnpm`
  - Setting up Node.js with version 22
  - Installing dependencies using `pnpm`
  - Building packages with `pnpm build`
  - Publishing packages with specific flags and using the GitHub token for authentication

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->