### PR TITLE
fix: remove invalid const Update sendTransactionForSession.ts

### DIFF
--- a/packages/agw-client/src/actions/sendTransactionForSession.ts
+++ b/packages/agw-client/src/actions/sendTransactionForSession.ts
@@ -45,7 +45,7 @@ export async function sendTransactionForSession<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
   account extends Account | undefined = Account | undefined,
   chainOverride extends ChainEIP712 | undefined = ChainEIP712 | undefined,
-  const request extends SendTransactionRequest<
+  request extends SendTransactionRequest<
     chain,
     chainOverride
   > = SendTransactionRequest<chain, chainOverride>,


### PR DESCRIPTION
Description:
This PR fixes a syntax error in the generic parameter list of sendTransactionForSession. The const keyword is not allowed when declaring generic type parameters in TypeScript. We remove const before request so that the file will compile correctly.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refines the type definitions in the `sendTransactionForSession.ts` file, enhancing the type parameters for better clarity and usability.

### Detailed summary
- Changed the type declaration for `request` to extend `SendTransactionRequest<chain, chainOverride>`.
- Updated the type parameters for `account` and `chainOverride` to allow for `undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->