### PR TITLE
fix: module path mismatches Update walletActions.test.ts

### DIFF
--- a/packages/agw-client/test/src/walletActions.test.ts
+++ b/packages/agw-client/test/src/walletActions.test.ts
@@ -19,15 +19,15 @@ import {
 import { address } from '../constants.js';
 
 // Mock the imported modules
-vi.mock('../../src/actions/sendTransaction');
-vi.mock('../../src/actions/signTransaction');
-vi.mock('../../src/actions/deployContract');
-vi.mock('../../src/actions/writeContract');
-vi.mock('../../src/actions/prepareTransaction');
-vi.mock('../../src/actions/writeContractForSession');
-vi.mock('../../src/actions/sendTransactionForSession');
-vi.mock('../../src/actions/sendTransactionBatch');
-vi.mock('../../src/actions/signTransactionBatch');
+vi.mock('../../src/actions/sendTransaction.js');
+vi.mock('../../src/actions/signTransaction.js');
+vi.mock('../../src/actions/deployContract.js');
+vi.mock('../../src/actions/writeContract.js');
+vi.mock('../../src/actions/prepareTransaction.js');
+vi.mock('../../src/actions/writeContractForSession.js');
+vi.mock('../../src/actions/sendTransactionForSession.js');
+vi.mock('../../src/actions/sendTransactionBatch.js');
+vi.mock('../../src/actions/signTransactionBatch.js');
 describe('globalWalletActions', () => {
   const mockSignerClient = {
     account: {


### PR DESCRIPTION
Description:
While writing Vitest tests, we were mocking modules using paths without the .js extension, but importing them elsewhere with .js. As a result, Vitest never applied our mocks (because the two strings didn’t match exactly), causing runtime errors like TypeError: X is not a function or failing toHaveBeenCalled checks. This PR makes the mock paths and import paths identical (including the .js) so that Vitest can correctly substitute the real module with our mock.

Vitest looked for ../../src/actions/sendTransaction but our import was ../../src/actions/sendTransaction.js—they didn’t align, so the mock never “took.”

Result:
After this change, Vitest will correctly intercept calls to those modules and replace them with our mocks. All tests that rely on expect(...).toHaveBeenCalled() for those modules should now pass without “module not found” or “function is not a function” errors.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the mock paths in the `walletActions.test.ts` file to include the `.js` extension for the action modules being mocked.

### Detailed summary
- Changed mock paths for the following actions to include the `.js` extension:
  - `sendTransaction`
  - `signTransaction`
  - `deployContract`
  - `writeContract`
  - `prepareTransaction`
  - `writeContractForSession`
  - `sendTransactionForSession`
  - `sendTransactionBatch`
  - `signTransactionBatch`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->