### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/agw-client-coverage.yml
+++ b/.github/workflows/agw-client-coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 

--- a/.github/workflows/agw-client-test.yml
+++ b/.github/workflows/agw-client-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 


### PR DESCRIPTION
Updated actions/setup-node to v4 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/actions/setup-node/releases/tag/v4.0.0

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Node.js setup action version in two workflow configuration files to improve compatibility and features.

### Detailed summary
- Updated `actions/setup-node` from `v3` to `v4` in `.github/workflows/agw-client-test.yml`.
- Updated `actions/setup-node` from `v3` to `v4` in `.github/workflows/agw-client-coverage.yml`.
- Set `node-version` to `'22'` in both workflow files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->