### PR TITLE
fix typo Update CHANGELOG.md

### DIFF
--- a/packages/agw-client/CHANGELOG.md
+++ b/packages/agw-client/CHANGELOG.md
@@ -74,7 +74,7 @@
 
 ### Patch Changes
 
-- 764642c: perf: remove reundant rpc call when sending transactions for sessions
+- 764642c: perf: remove redundant rpc call when sending transactions for sessions
 
 ## 1.6.2
 


### PR DESCRIPTION
«reundant» → «redundant»

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving performance by removing a redundant RPC call when sending transactions for sessions.

### Detailed summary
- Updated the changelog entry for version `1.6.2` to correct a typo in the description.
- Removed the word "reundant" and replaced it with "redundant" in the changelog for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->