### PR TITLE
fix: update deprecated link to correct Oku Motion documentation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2079,7 +2079,7 @@ packages:
       {
         integrity: sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==,
       }
-    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion
+    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://motion.oku-ui.com
 
   '@noble/ciphers@1.2.1':
     resolution:


### PR DESCRIPTION
Replaced the broken link https://oku-ui.com/motion with the correct documentation link https://motion.oku-ui.com in the deprecation message for Motion One for Vue.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the deprecation notice for `Motion One for Vue`, directing users to the new URL for `Oku Motion`. 

### Detailed summary
- Updated the deprecation message for `Motion One for Vue`.
- Changed the URL from `https://oku-ui.com/motion` to `https://motion.oku-ui.com`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->