### PR TITLE
Replace deprecated Wagmi v2 Update abstractPrivyProvider.tsx

### DIFF
--- a/packages/agw-react/src/privy/abstractPrivyProvider.tsx
+++ b/packages/agw-react/src/privy/abstractPrivyProvider.tsx
@@ -7,7 +7,7 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { type Chain, type Transport } from 'viem';
-import { createConfig, http, WagmiProvider } from 'wagmi';
+import { createConfig, http, WagmiConfig } from 'wagmi';
 
 import { AGW_APP_ID } from '../constants.js';
 import { InjectWagmiConnector } from './injectWagmiConnector.js';
@@ -34,7 +34,7 @@ interface AgwPrivyProviderProps extends PrivyProviderProps {
  * This component wraps your application with the necessary providers to use Abstract Global Wallet
  * with Privy authentication, including:
  * - PrivyProvider: Handles user authentication and EOA creation
- * - WagmiProvider: Provides web3 functionality
+ * - WagmiConfig: Provides web3 functionality
  * - QueryClientProvider: Manages data fetching with TanStack Query
  * - InjectWagmiConnector: Injects the Abstract wallet into Wagmi
  *
@@ -103,13 +103,13 @@ export const AbstractPrivyProvider = ({
   }
   return (
     <PrivyProvider {...props}>
-      <WagmiProvider config={wagmiConfig}>
+      <WagmiConfig config={wagmiConfig}>
         <QueryClientProvider client={queryClient}>
           <InjectWagmiConnector chain={chain} transport={transport}>
             {props.children}
           </InjectWagmiConnector>
         </QueryClientProvider>
-      </WagmiProvider>
+      </WagmiConfig>
     </PrivyProvider>
   );
 };


### PR DESCRIPTION
Description:
In Wagmi v2 the <WagmiProvider> component was removed in favor of <WagmiConfig>. This commit updates our imports and JSX accordingly so that our provider tree works with the latest Wagmi release.

Changes:

Import

Replace import { …, WagmiProvider } from 'wagmi'

With import { …, WagmiConfig } from 'wagmi'

This fixes runtime errors when using Wagmi v2, as WagmiProvider is no longer exported.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `WagmiProvider` to `WagmiConfig` in the `AbstractPrivyProvider` component, reflecting changes in the `wagmi` library's API. It also updates the documentation comments to match this change.

### Detailed summary
- Replaced `WagmiProvider` with `WagmiConfig` in the `AbstractPrivyProvider`.
- Updated documentation comments to reflect the change from `WagmiProvider` to `WagmiConfig`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->