### PR TITLE
fixes incorrect usage in Update writeContractSponsored.ts

### DIFF
--- a/packages/agw-react/src/query/writeContractSponsored.ts
+++ b/packages/agw-react/src/query/writeContractSponsored.ts
@@ -19,7 +19,7 @@ export function writeContractSponsoredMutationOptions<config extends Config>(
 ) {
   return {
     mutationFn(variables) {
-      return writeContract(config, variables);
+      return writeContract(variables);
     },
     mutationKey: ['writeContract'],
   } as const satisfies MutationOptions<


### PR DESCRIPTION
This PR fixes incorrect usage of writeContract in writeContractSponsoredMutationOptions. The writeContract function from @wagmi/core does not accept the React config object as its first argument; it expects a single object containing the transaction parameters.