### PR TITLE
fix: improve smart account deployment detection

### DIFF
--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -97,7 +97,7 @@ export async function isSmartAccountDeployed<
   const bytecode = await publicClient.getCode({
     address: address,
   });
-  return bytecode !== undefined;
+  return bytecode !== undefined && bytecode !== '0x';
 }
 
 export function getInitializerCalldata(


### PR DESCRIPTION
Fix the isSmartAccountDeployed function to correctly detect non-existent contracts by checking if the bytecode is '0x' (empty bytecode) in addition to checking if it's undefined.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the function that checks the validity of `bytecode` by ensuring it is not only defined but also not equal to `'0x'`. This improves the robustness of the validation process.

### Detailed summary
- Modified the return statement in the function to check that `bytecode` is not `undefined` and not equal to `'0x'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->