### PR TITLE
fix: correct parseAccount import in transformEIP1193Provider.ts

### DIFF
--- a/packages/agw-client/src/transformEIP1193Provider.ts
+++ b/packages/agw-client/src/transformEIP1193Provider.ts
@@ -17,7 +17,8 @@ import {
   toHex,
   type Transport,
 } from 'viem';
-import { parseAccount, toAccount } from 'viem/accounts';
+import { toAccount } from 'viem/accounts';
+import { parseAccount } from 'viem/utils';
 
 import { createAbstractClient } from './abstractClient.js';
 import {


### PR DESCRIPTION
Import parseAccount from 'viem/utils' instead of 'viem/accounts' to match its usage in the file. This removes an unnecessary import and ensures consistent import sources throughout the codebase, improving maintainability and preventing potential version conflicts

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the imports in the `packages/agw-client/src/transformEIP1193Provider.ts` file to streamline the account parsing functionality by importing `parseAccount` from a different module.

### Detailed summary
- Changed import of `parseAccount` from `viem/accounts` to `viem/utils`.
- Retained import of `toAccount` from `viem/accounts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->