### PR TITLE
fix typing

### DIFF
--- a/.changeset/honest-coats-trade.md
+++ b/.changeset/honest-coats-trade.md
@@ -1,0 +1,5 @@
+---
+'@abstract-foundation/agw-client': patch
+---
+
+fix typing on AbstractWalletActions.getLinkedAccounts

--- a/packages/agw-client/src/walletActions.ts
+++ b/packages/agw-client/src/walletActions.ts
@@ -90,9 +90,7 @@ export type AbstractWalletActions<
   account extends Account | undefined = Account | undefined,
 > = Eip712WalletActions<chain, account> & {
   getChainId: () => Promise<GetChainIdReturnType>;
-  getLinkedAccounts: (
-    args: GetLinkedAccountsParameters,
-  ) => Promise<GetLinkedAccountsReturnType>;
+  getLinkedAccounts: () => Promise<GetLinkedAccountsReturnType>;
   isLinkedAccount: (args: IsLinkedAccountParameters) => Promise<boolean>;
   createSession: (
     args: CreateSessionParameters,


### PR DESCRIPTION
- **fix: bad typing on AbstractWalletActions.getLinkedAccounts**
- **cs**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the typing for the `getLinkedAccounts` method in the `AbstractWalletActions` interface within the `agw-client` package.

### Detailed summary
- Updated the `getLinkedAccounts` method signature in `AbstractWalletActions`:
  - Changed from accepting `GetLinkedAccountsParameters` to no arguments.
  - Returns `Promise<GetLinkedAccountsReturnType>`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->