### PR TITLE
Update package.json: Remove typings

### DIFF
--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -22,7 +22,6 @@
   "main": "./dist/cjs/exports/index.js",
   "module": "./dist/esm/exports/index.js",
   "types": "./dist/types/exports/index.d.ts",
-  "typings": "./dist/types/exports/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/exports/index.d.ts",


### PR DESCRIPTION
1)The typings field is an outdated field used in earlier versions of TypeScript (before ~2.0) as an alternative to types. It served the same purpose, but with the release of TypeScript 2.0 and later, types became the standard, and typings became deprecated. TypeScript still supports typings for backward compatibility, but its use is not recommended.
2)Having two fields pointing to the same file does not add functionality but increases the likelihood of confusion. For example, if you update the path in types in the future but forget to update typings, it could lead to inconsistencies, and some tools might attempt to use the outdated path.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `package.json` file in the `agw-client` package to streamline type definitions and exports.

### Detailed summary
- Removed the `"typings"` field from `package.json`.
- Confirmed that the `"types"` field still points to `./dist/types/exports/index.d.ts`.
- Maintained the structure of the `"exports"` field for module resolution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->