### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/agw-client-coverage.yml
+++ b/.github/workflows/agw-client-coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/agw-client-test.yml
+++ b/.github/workflows/agw-client-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/publish-npm-packages-private.yml
+++ b/.github/workflows/publish-npm-packages-private.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -12,7 +12,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `checkout` action version from `v4` to `v5` across multiple workflow files, ensuring the latest features and improvements are utilized.

### Detailed summary
- Updated `actions/checkout` from `v4` to `v5` in:
  - `.github/workflows/agw-client-test.yml`
  - `.github/workflows/agw-client-coverage.yml`
  - `.github/workflows/build-test.yml`
  - `.github/workflows/release.yml`
  - `.github/workflows/publish-npm-packages.yml`
  - `.github/workflows/publish-npm-packages-private.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->