### PR TITLE
Fix: correctly detect undeployed smart accounts

### DIFF
--- a/packages/agw-client/src/utils.ts
+++ b/packages/agw-client/src/utils.ts
@@ -97,7 +97,7 @@ export async function isSmartAccountDeployed<
   const bytecode = await publicClient.getCode({
     address: address,
   });
-  return bytecode !== undefined;
+  return bytecode != null && bytecode !== '0x';
 }
 
 export function getInitializerCalldata(

--- a/packages/agw-client/test/src/utils.test.ts
+++ b/packages/agw-client/test/src/utils.test.ts
@@ -103,6 +103,19 @@ describe('isSmartAccountDeployed', () => {
 
   it('should return false if smart account is not deployed', async () => {
     const publicClient = {
+      getCode: vi.fn().mockResolvedValue('0x'),
+    };
+    const smartAccountAddress = address.smartAccountAddress;
+    expect(
+      isSmartAccountDeployed(publicClient as any, smartAccountAddress),
+    ).resolves.toBe(false);
+    expect(publicClient.getCode).toHaveBeenCalledWith({
+      address: smartAccountAddress,
+    });
+  });
+
+  it('should return false if getCode returns undefined', async () => {
+    const publicClient = {
       getCode: vi.fn().mockResolvedValue(undefined),
     };
     const smartAccountAddress = address.smartAccountAddress;


### PR DESCRIPTION
### Summary
- Corrected `isSmartAccountDeployed` to treat `null`, `undefined`, and "0x" responses from `eth_getCode` as undeployed.
- Expanded unit tests to validate behavior for empty bytecode and undefined responses.
- Prevents false positives in deployment checks, ensuring smart accounts are only flagged as deployed when bytecode is present.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the functionality and testing of smart account deployment checks in the `agw-client` package, as well as adding a polyfill for `Promise.withResolvers`.

### Detailed summary
- Updated the return condition in the function to check if `bytecode` is not null and not equal to `'0x'`.
- Added a test case to verify that `isSmartAccountDeployed` returns `false` when `getCode` resolves to `'0x'`.
- Added another test case for when `getCode` returns `undefined`.
- Added a polyfill for `Promise.withResolvers` for compatibility with older Node.js versions.
- Enhanced the shutdown logic in the global setup to ensure proper instance management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->