### PR TITLE
test: add tests for linkable decorators

### DIFF
--- a/packages/agw-client/test/src/clients/decorators/linkablePublic.test.ts
+++ b/packages/agw-client/test/src/clients/decorators/linkablePublic.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as getLinkedAccountsModule from '../../../../src/actions/getLinkedAccounts.js';
+import * as getLinkedAgwModule from '../../../../src/actions/getLinkedAgw.js';
+import { linkablePublicActions } from '../../../../src/clients/decorators/linkablePublic.js';
+
+// Mock the imported modules
+vi.mock('../../../../src/actions/getLinkedAgw');
+vi.mock('../../../../src/actions/getLinkedAccounts');
+
+describe('linkablePublicActions', () => {
+  const mockPublicClient = {} as any;
+
+  const actions = linkablePublicActions()(mockPublicClient);
+
+  it('should return an object with all expected methods', () => {
+    expect(actions).toHaveProperty('getLinkedAgw');
+    expect(actions).toHaveProperty('getLinkedAccounts');
+  });
+
+  it('should call getLinkedAgw with correct arguments', async () => {
+    const mockArgs = {
+      address: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+    };
+    await actions.getLinkedAgw(mockArgs as any);
+    expect(getLinkedAgwModule.getLinkedAgw).toHaveBeenCalledWith(
+      mockPublicClient,
+      mockArgs,
+    );
+  });
+
+  it('should call getLinkedAccounts with correct arguments', async () => {
+    const mockArgs = {
+      agwAddress: '0xCD2a39F938E13CD947Ec05AbC7FE734Df8DD826',
+    };
+    await actions.getLinkedAccounts(mockArgs as any);
+    expect(getLinkedAccountsModule.getLinkedAccounts).toHaveBeenCalledWith(
+      mockPublicClient,
+      mockArgs,
+    );
+  });
+});

--- a/packages/agw-client/test/src/clients/decorators/linkableWallet.test.ts
+++ b/packages/agw-client/test/src/clients/decorators/linkableWallet.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as getLinkedAgwModule from '../../../../src/actions/getLinkedAgw.js';
+import * as linkToAgwModule from '../../../../src/actions/linkToAgw.js';
+import { linkableWalletActions } from '../../../../src/clients/decorators/linkableWallet.js';
+
+// Mock the imported modules
+vi.mock('../../../../src/actions/getLinkedAgw');
+vi.mock('../../../../src/actions/linkToAgw');
+
+describe('linkableWalletActions', () => {
+  const mockWalletClient = {} as any;
+
+  const actions = linkableWalletActions()(mockWalletClient);
+
+  it('should return an object with all expected methods', () => {
+    expect(actions).toHaveProperty('linkToAgw');
+    expect(actions).toHaveProperty('getLinkedAgw');
+  });
+
+  it('should call linkToAgw with correct arguments', async () => {
+    const mockArgs = {
+      agwAddress: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+    };
+    await actions.linkToAgw(mockArgs as any);
+    expect(linkToAgwModule.linkToAgw).toHaveBeenCalledWith(
+      mockWalletClient,
+      mockArgs,
+    );
+  });
+
+  it('should call getLinkedAgw with correct arguments', async () => {
+    await actions.getLinkedAgw();
+    expect(getLinkedAgwModule.getLinkedAgw).toHaveBeenCalledWith(
+      mockWalletClient,
+      {},
+    );
+  });
+});


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds unit tests for the `linkableWalletActions` and `linkablePublicActions` decorators in the AGW client. It verifies that the actions return the expected methods and correctly call the respective imported functions with the appropriate arguments.

### Detailed summary
- Added tests for `linkableWalletActions` in `linkableWallet.test.ts`.
  - Verified the presence of `linkToAgw` and `getLinkedAgw` methods.
  - Tested `linkToAgw` to ensure correct arguments are passed.
  - Tested `getLinkedAgw` to ensure correct arguments are passed.
  
- Added tests for `linkablePublicActions` in `linkablePublic.test.ts`.
  - Verified the presence of `getLinkedAgw` and `getLinkedAccounts` methods.
  - Tested `getLinkedAgw` to ensure correct arguments are passed.
  - Tested `getLinkedAccounts` to ensure correct arguments are passed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->