### PR TITLE
Fix: add missing await when creating Abstract client

### DIFF
--- a/.changeset/thick-colts-hammer.md
+++ b/.changeset/thick-colts-hammer.md
@@ -1,0 +1,5 @@
+---
+"@abstract-foundation/agw-react": patch
+---
+
+Fix: add missing await when creating Abstract client

--- a/packages/agw-react/src/hooks/useAbstractClient.ts
+++ b/packages/agw-react/src/hooks/useAbstractClient.ts
@@ -69,7 +69,7 @@ export const useAbstractClient = ({
         throw new Error('No signer found');
       }
 
-      const client = createAbstractClient({
+      const client = await createAbstractClient({
         signer: signer.account,
         chain,
         transport: custom(signer.transport),


### PR DESCRIPTION
Ensure that the result of `createAbstractClient` is awaited within `queryFn` so that the resolved client instance is returned.

This improves consistency and avoids potential issues with unresolved promises.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue by adding a missing `await` when creating an `Abstract` client, ensuring that the client is properly initialized before use.

### Detailed summary
- Added `await` keyword to the `createAbstractClient` function call in `packages/agw-react/src/hooks/useAbstractClient.ts` to ensure proper asynchronous handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->