### PR TITLE
Fix README example: define missing chain and signer in paymaster section

### DIFF
--- a/packages/agw-client/README.md
+++ b/packages/agw-client/README.md
@@ -60,11 +60,20 @@ Asynchronously creates an `AbstractClient` instance, extending the standard `Cli
 
 ```tsx
 import { createAbstractClient } from '@abstract-foundation/agw-client';
+import { abstractTestnet } from 'viem/chains';
+import { Account } from 'viem/accounts';
+
+const signer: Account = {
+  address: '0xYourSignerAddress',
+  // ...other account properties
+};
+
+const chain = abstractTestnet;
 
 (async () => {
   const abstractClient = await createAbstractClient({
-    signer: /* your signer account */,
-    chain: /* your chain configuration */,
+    signer,
+    chain,
   });
 
   // Use abstractClient to interact with the blockchain


### PR DESCRIPTION
This PR fixes the example in the "API Reference" section of the README file.

In the “Quick Start” section example, the `signer` and `chain` variables are imported and used, which provides a convenient user experience. The "API Reference" section uses different logic:
```ts
const abstractClient = await createAbstractClient({
   signer: /* your signer account */,
   chain: /* your chain configuration */,
// ...
```

Based on the example from “Quick Start,” I implemented the same logic in "API Reference":
Added imports:
- `abstractTestnet from viem/chains`
- `Account from viem/accounts`

Declared the necessary variables:
- `const chain = abstractTestnet`
- `const signer: Account = { ... }`

Updated the use of `createAbstractClient` to reference the defined variables.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `README.md` file in the `agw-client` package to include specific configurations for the `signer` and `chain` when creating an `abstractClient`, enhancing clarity for users on how to set up their client.

### Detailed summary
- Added import for `abstractTestnet` from `viem/chains`.
- Added import for `Account` from `viem/accounts`.
- Defined a `signer` object with an `address` property.
- Set the `chain` variable to `abstractTestnet`.
- Updated the `createAbstractClient` call to use the defined `signer` and `chain` variables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->