### PR TITLE
fix: make getLinkedAgw parameters optional

### DIFF
--- a/.changeset/funny-pugs-thank.md
+++ b/.changeset/funny-pugs-thank.md
@@ -1,0 +1,5 @@
+---
+"@abstract-foundation/agw-client": minor
+---
+
+Tighten `getLinkedAgw` typing so account-hoisted clients can call it with zero arguments, while clients without a hoisted account must pass `{ address }`.

--- a/packages/agw-client/src/actions/getLinkedAgw.ts
+++ b/packages/agw-client/src/actions/getLinkedAgw.ts
@@ -72,7 +72,7 @@ export async function getLinkedAgw<
   account extends Account | undefined = Account | undefined,
 >(
   client: Client<Transport, chain, account>,
-  parameters: GetLinkedAgwParameters,
+  parameters: GetLinkedAgwParameters = {},
 ): Promise<GetLinkedAgwReturnType> {
   const { address = client.account?.address } = parameters;
 

--- a/packages/agw-client/src/actions/getLinkedAgw.ts
+++ b/packages/agw-client/src/actions/getLinkedAgw.ts
@@ -6,7 +6,9 @@ import {
   type Client,
   getAddress,
   InvalidAddressError,
+  type IsUndefined,
   isAddress,
+  type MaybeRequired,
   type Transport,
 } from 'viem';
 import { readContract } from 'viem/actions';
@@ -24,9 +26,19 @@ export interface GetLinkedAgwReturnType {
   agw: Address | undefined;
 }
 
-export interface GetLinkedAgwParameters {
-  address?: Address | undefined;
-}
+export type GetLinkedAgwParameters<
+  account extends Account | undefined = Account | undefined,
+> = MaybeRequired<{ address?: Address | undefined }, IsUndefined<account>>;
+
+export type GetLinkedAgwAction<
+  account extends Account | undefined = Account | undefined,
+> = IsUndefined<account> extends true
+  ? (
+      parameters: GetLinkedAgwParameters<account>,
+    ) => Promise<GetLinkedAgwReturnType>
+  : (
+      parameters?: GetLinkedAgwParameters<account>,
+    ) => Promise<GetLinkedAgwReturnType>;
 
 export interface IsLinkedAccountParameters {
   address: Address;
@@ -63,18 +75,33 @@ export interface IsLinkedAccountParameters {
  * }
  * ```
  *
- * @param parameters - Parameters for getting the linked AGW
+ * @param parameters - Parameters for getting the linked AGW. If the client has a connected account, this can be omitted
  * @param parameters.address - The Ethereum Mainnet address to check for a linked AGW. If not provided, defaults to the connected account's address
  * @returns Object containing the address of the linked AGW, or undefined if no AGW is linked
  */
 export async function getLinkedAgw<
   chain extends Chain | undefined = Chain | undefined,
+>(
+  client: Client<Transport, chain, undefined>,
+  parameters: GetLinkedAgwParameters<undefined>,
+): Promise<GetLinkedAgwReturnType>;
+export async function getLinkedAgw<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account = Account,
+>(
+  client: Client<Transport, chain, account>,
+  parameters?: GetLinkedAgwParameters<account>,
+): Promise<GetLinkedAgwReturnType>;
+export async function getLinkedAgw<
+  chain extends Chain | undefined = Chain | undefined,
   account extends Account | undefined = Account | undefined,
 >(
   client: Client<Transport, chain, account>,
-  parameters: GetLinkedAgwParameters = {},
+  parameters?: GetLinkedAgwParameters<account>,
 ): Promise<GetLinkedAgwReturnType> {
-  const { address = client.account?.address } = parameters;
+  const { address = client.account?.address } = (parameters ?? {}) as {
+    address?: Address | undefined;
+  };
 
   if (address === undefined) {
     throw new BaseError('No address provided');

--- a/packages/agw-client/src/clients/decorators/linkablePublic.ts
+++ b/packages/agw-client/src/clients/decorators/linkablePublic.ts
@@ -6,15 +6,15 @@ import {
   getLinkedAccounts,
 } from '../../actions/getLinkedAccounts.js';
 import {
+  type GetLinkedAgwAction,
   type GetLinkedAgwParameters,
-  type GetLinkedAgwReturnType,
   getLinkedAgw,
 } from '../../actions/getLinkedAgw.js';
 
-export interface LinkablePublicActions {
-  getLinkedAgw: (
-    args: GetLinkedAgwParameters,
-  ) => Promise<GetLinkedAgwReturnType>;
+export interface LinkablePublicActions<
+  account extends Account | undefined = Account | undefined,
+> {
+  getLinkedAgw: GetLinkedAgwAction<account>;
   getLinkedAccounts: (
     args: GetLinkedAccountsParameters,
   ) => Promise<GetLinkedAccountsReturnType>;
@@ -25,10 +25,18 @@ export function linkablePublicActions<
   chain extends ChainEIP712 | undefined = ChainEIP712 | undefined,
   account extends Account | undefined = Account | undefined,
 >() {
-  return (
-    client: Client<transport, chain, account>,
-  ): LinkablePublicActions => ({
-    getLinkedAgw: (args) => getLinkedAgw(client, args),
+  return <
+    clientTransport extends transport = transport,
+    clientChain extends chain = chain,
+    clientAccount extends account = account,
+  >(
+    client: Client<clientTransport, clientChain, clientAccount>,
+  ): LinkablePublicActions<clientAccount> => ({
+    getLinkedAgw: ((parameters?: GetLinkedAgwParameters<clientAccount>) =>
+      getLinkedAgw(
+        client as Client<clientTransport, clientChain, Account>,
+        (parameters ?? {}) as GetLinkedAgwParameters<Account>,
+      )) as GetLinkedAgwAction<clientAccount>,
     getLinkedAccounts: (args) => getLinkedAccounts(client, args),
   });
 }

--- a/packages/agw-client/src/clients/decorators/linkableWallet.ts
+++ b/packages/agw-client/src/clients/decorators/linkableWallet.ts
@@ -7,7 +7,8 @@ import {
   walletActions,
 } from 'viem';
 import {
-  type GetLinkedAgwReturnType,
+  type GetLinkedAgwAction,
+  type GetLinkedAgwParameters,
   getLinkedAgw,
 } from '../../actions/getLinkedAgw.js';
 import {
@@ -21,7 +22,7 @@ export type LinkableWalletActions<
   account extends Account | undefined = Account | undefined,
 > = WalletActions<chain, account> & {
   linkToAgw: (args: LinkToAgwParameters) => Promise<LinkToAgwReturnType>;
-  getLinkedAgw: () => Promise<GetLinkedAgwReturnType>;
+  getLinkedAgw: GetLinkedAgwAction<account>;
 };
 
 export function linkableWalletActions<
@@ -29,11 +30,19 @@ export function linkableWalletActions<
   chain extends Chain | undefined = Chain | undefined,
   account extends Account | undefined = Account | undefined,
 >() {
-  return (
-    client: WalletClient<transport, chain, account>,
-  ): LinkableWalletActions<chain, account> => ({
+  return <
+    clientTransport extends transport = transport,
+    clientChain extends chain = chain,
+    clientAccount extends account = account,
+  >(
+    client: WalletClient<clientTransport, clientChain, clientAccount>,
+  ): LinkableWalletActions<clientChain, clientAccount> => ({
     ...walletActions(client),
     linkToAgw: (args) => linkToAgw(client, args),
-    getLinkedAgw: () => getLinkedAgw(client, {}),
+    getLinkedAgw: ((parameters?: GetLinkedAgwParameters<clientAccount>) =>
+      getLinkedAgw(
+        client as WalletClient<clientTransport, clientChain, Account>,
+        (parameters ?? {}) as GetLinkedAgwParameters<Account>,
+      )) as GetLinkedAgwAction<clientAccount>,
   });
 }

--- a/packages/agw-client/test/src/actions/getLinkedAgw.test.ts
+++ b/packages/agw-client/test/src/actions/getLinkedAgw.test.ts
@@ -1,0 +1,51 @@
+import { createClient, getAddress } from 'viem';
+import { ChainEIP712 } from 'viem/zksync';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getLinkedAgw } from '../../../src/actions/getLinkedAgw.js';
+import {
+  AGW_LINK_DELEGATION_RIGHTS,
+  CANONICAL_EXCLUSIVE_DELEGATE_RESOLVER_ADDRESS,
+} from '../../../src/constants.js';
+import { anvilAbstractTestnet } from '../../anvil.js';
+import { address } from '../../constants.js';
+
+vi.mock('viem/actions', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    readContract: vi.fn(),
+  };
+});
+
+import { readContract } from 'viem/actions';
+
+const baseClient = createClient({
+  account: address.smartAccountAddress,
+  chain: anvilAbstractTestnet.chain as ChainEIP712,
+  transport: anvilAbstractTestnet.clientConfig.transport,
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('getLinkedAgw', () => {
+  it('uses the connected account when parameters are omitted', async () => {
+    const linkedAgw = '0x1234567890123456789012345678901234567890';
+    vi.mocked(readContract).mockResolvedValue(linkedAgw);
+
+    const result = await getLinkedAgw(baseClient);
+
+    expect(readContract).toHaveBeenCalledWith(baseClient, {
+      abi: expect.any(Array),
+      address: CANONICAL_EXCLUSIVE_DELEGATE_RESOLVER_ADDRESS,
+      functionName: 'exclusiveWalletByRights',
+      args: [
+        getAddress(address.smartAccountAddress),
+        AGW_LINK_DELEGATION_RIGHTS,
+      ],
+    });
+    expect(result).toEqual({ agw: linkedAgw });
+  });
+});


### PR DESCRIPTION
The `getLinkedAgw` action already falls back to `client.account?.address` when no address is provided, but its signature still required a `GetLinkedAgwParameters` object.

This makes the second argument optional so consumers can call `getLinkedAgw(client)` directly, matching the existing behavior exposed through `linkableWalletActions().getLinkedAgw()` and reducing unnecessary boilerplate.

## Changes

- make `parameters` optional in `getLinkedAgw`
- add a unit test covering direct action usage without parameters

## Risk

Low. This is a small additive API improvement with no change to the existing fallback/error behavior.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on tightening the typing of the `getLinkedAgw` function to allow clients with hoisted accounts to call it without parameters, while requiring an address for clients without hoisted accounts. It also includes updates to related interfaces and tests.

### Detailed summary
- Updated `LinkablePublicActions` and `LinkableWalletActions` to use `GetLinkedAgwAction` for `getLinkedAgw`.
- Modified `getLinkedAgw` function signatures to support optional parameters.
- Enhanced type definitions for `GetLinkedAgwParameters` to conditionally require `address`.
- Added tests for `getLinkedAgw` to validate behavior with omitted parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->