### PR TITLE
docs: fix mismatch in INSUFFICIENT_BALANCE selector comment

### DIFF
--- a/packages/agw-client/src/constants.ts
+++ b/packages/agw-client/src/constants.ts
@@ -26,7 +26,7 @@ const CREATE_SESSION_SELECTOR = '0x5a0694d2' as const;
 /** `function batchCall((address,bool,uint256,bytes)[]) external` */
 const BATCH_CALL_SELECTOR = '0x8f0273a9' as const;
 
-/** `error INSUFFICIENT_FUNDS()` */
+/** `error INSUFFICIENT_BALANCE()` */
 const INSUFFICIENT_BALANCE_SELECTOR = '0xe7931438' as const;
 
 const CANONICAL_DELEGATE_REGISTRY_ADDRESS =


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation comment for an error constant in the `constants.ts` file, changing it from `INSUFFICIENT_FUNDS` to `INSUFFICIENT_BALANCE`. This change clarifies the meaning of the error related to balance checks.

### Detailed summary
- Renamed documentation comment from `error INSUFFICIENT_FUNDS()` to `error INSUFFICIENT_BALANCE()` for `INSUFFICIENT_BALANCE_SELECTOR`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->