### PR TITLE
fix: use publicClient for estimate gas

### DIFF
--- a/.changeset/twelve-foxes-swim.md
+++ b/.changeset/twelve-foxes-swim.md
@@ -1,0 +1,5 @@
+---
+"@abstract-foundation/agw-client": patch
+---
+
+Use publicClient for estimate gas instead of internal/wrapped transport

--- a/packages/agw-client/package.json
+++ b/packages/agw-client/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/node": "^22.12.5",
     "@vitest/coverage-v8": "^3.2.4",
-    "prool": "^0.0.23",
+    "prool": "^0.2.4",
     "viem": "^2.37.0",
     "vitest": "^3.2.4"
   },

--- a/packages/agw-client/src/actions/prepareTransaction.ts
+++ b/packages/agw-client/src/actions/prepareTransaction.ts
@@ -426,7 +426,7 @@ export async function prepareTransactionRequest<
       (async () => {
         try {
           request.gas = await getAction(
-            client,
+            publicClient,
             estimateGas,
             'estimateGas',
           )({

--- a/packages/agw-client/test/anvil.ts
+++ b/packages/agw-client/test/anvil.ts
@@ -1,5 +1,4 @@
-import { createServer } from 'prool';
-import { type AnvilParameters, anvil } from 'prool/instances';
+import { Instance, Server } from 'prool';
 import {
   type Account,
   type Address,
@@ -49,7 +48,7 @@ function getEnv(key: string, fallback: string): string {
 }
 
 type DefineAnvilParameters<chain extends Chain> = Omit<
-  AnvilParameters,
+  Instance.anvil.Parameters,
   'forkBlockNumber' | 'forkUrl'
 > & {
   chain: chain;
@@ -208,8 +207,8 @@ function defineAnvil<const chain extends Chain>(
       await fetch(`${rpcUrl.http}/restart`);
     },
     async start() {
-      return await createServer({
-        instance: anvil({
+      return await Server.create({
+        instance: Instance.anvil({
           forkUrl,
           forkBlockNumber,
           ...options,

--- a/packages/agw-client/test/debug-global-setup.ts
+++ b/packages/agw-client/test/debug-global-setup.ts
@@ -1,0 +1,12 @@
+import globalSetup from './globalSetup.ts';
+
+async function main() {
+  const stop = await globalSetup();
+  console.log('global setup ok', typeof stop);
+  if (typeof stop === 'function') await stop();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/agw-client/test/src/actions/prepareTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/prepareTransaction.test.ts
@@ -1,5 +1,6 @@
 import {
   createClient,
+  createWalletClient,
   EIP1193RequestFn,
   encodeFunctionData,
   http,

--- a/packages/agw-client/test/src/actions/prepareTransaction.test.ts
+++ b/packages/agw-client/test/src/actions/prepareTransaction.test.ts
@@ -1,15 +1,14 @@
 import {
   createClient,
-  createNonceManager,
-  createPublicClient,
-  createWalletClient,
   EIP1193RequestFn,
   encodeFunctionData,
   http,
   keccak256,
   NonceManager,
-  nonceManager,
+  PublicClient,
   parseEther,
+  publicActions,
+  Transport,
   toBytes,
   toHex,
 } from 'viem';
@@ -63,6 +62,12 @@ const baseClientRequestSpy = vi.fn(async ({ method, params }) => {
   }
   if (method === 'eth_estimateGas') {
     return MOCK_ETH_ESTIMATE_GAS_LIMIT;
+  } else if (method === 'zks_estimateFee') {
+    throw new Error('zks_estimateFee not supported');
+  } else if (method === 'eth_gasPrice') {
+    return toHex(MOCK_FEE_PER_GAS);
+  } else if (method === 'eth_getBalance') {
+    return toHex(1000000000000000000n); // 1 ETH
   }
   return anvilAbstractTestnet.getClient().request({ method, params } as any);
 });
@@ -82,23 +87,9 @@ signerClient.request = (async ({ method, params }) => {
   return anvilAbstractTestnet.getClient().request({ method, params } as any);
 }) as EIP1193RequestFn;
 
-const publicClient = createPublicClient({
-  chain: anvilAbstractTestnet.chain as ChainEIP712,
-  transport: anvilAbstractTestnet.clientConfig.transport,
-});
-
-publicClient.request = (async ({ method, params }) => {
-  if (method === 'zks_estimateFee') {
-    throw new Error('zks_estimateFee not supported');
-  } else if (method === 'eth_estimateGas') {
-    return toHex(MOCK_ETH_ESTIMATE_GAS_LIMIT);
-  } else if (method === 'eth_gasPrice') {
-    return toHex(MOCK_FEE_PER_GAS);
-  } else if (method === 'eth_getBalance') {
-    return toHex(1000000000000000000n); // 1 ETH
-  }
-  return anvilAbstractTestnet.getClient().request({ method, params } as any);
-}) as EIP1193RequestFn;
+const publicClient = baseClient.extend(
+  publicActions,
+) as unknown as PublicClient<Transport, ChainEIP712>;
 
 publicClient.getTransactionCount = vi.fn(async () => {
   return MOCK_NONCE;
@@ -354,13 +345,13 @@ test.each([
 ])('$name', async ({ balance, value, isSponsored, errorType }) => {
   vi.mocked(isSmartAccountDeployed).mockResolvedValue(true);
 
-  // Create a modified public client that returns a specified balance
-  const publicClientWithCustomBalance = createPublicClient({
+  const customBaseClient = createClient({
+    account: address.smartAccountAddress,
     chain: anvilAbstractTestnet.chain as ChainEIP712,
     transport: anvilAbstractTestnet.clientConfig.transport,
   });
 
-  publicClientWithCustomBalance.request = (async ({ method, params }) => {
+  customBaseClient.request = (async ({ method, params }) => {
     if (method === 'zks_estimateFee') {
       throw new Error('zks_estimateFee not supported');
     } else if (method === 'eth_estimateGas') {
@@ -372,6 +363,11 @@ test.each([
     }
     return anvilAbstractTestnet.getClient().request({ method, params } as any);
   }) as EIP1193RequestFn;
+
+  // Create a modified public client that returns a specified balance
+  const publicClientWithCustomBalance = customBaseClient.extend(
+    publicActions,
+  ) as unknown as PublicClient<Transport, ChainEIP712>;
 
   const txWithoutPaymaster = {
     ...transaction,

--- a/packages/agw-client/test/src/actions/sendTransactionInternal.test.ts
+++ b/packages/agw-client/test/src/actions/sendTransactionInternal.test.ts
@@ -7,7 +7,10 @@ import {
   encodeAbiParameters,
   Hex,
   http,
+  PublicClient,
   parseAbiParameters,
+  publicActions,
+  Transport,
   toFunctionSelector,
 } from 'viem';
 import { toAccount } from 'viem/accounts';
@@ -102,13 +105,14 @@ signerClient.request = (async ({ method, params }) => {
   return anvilAbstractTestnet.getClient().request({ method, params } as any);
 }) as EIP1193RequestFn;
 
-const publicClient = createPublicClient({
-  chain: anvilAbstractTestnet.chain as ChainEIP712,
-  transport: anvilAbstractTestnet.clientConfig.transport,
-});
+const publicClient = baseClient.extend(
+  publicActions,
+) as unknown as PublicClient<Transport, ChainEIP712>;
 
 publicClient.request = (async ({ method, params }) => {
-  if (method === 'zks_estimateFee') {
+  if (method === 'eth_estimateGas') {
+    return 158774n;
+  } else if (method === 'zks_estimateFee') {
     throw new Error('zks_estimateFee not supported');
   }
   return anvilAbstractTestnet.getClient().request({ method, params } as any);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.9)(jiti@1.21.6)(terser@5.43.1)(yaml@2.8.1))
       prool:
-        specifier: ^0.0.23
-        version: 0.0.23
+        specifier: ^0.2.4
+        version: 0.2.4
       viem:
         specifier: ^2.37.0
         version: 2.45.1(bufferutil@4.0.9)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -3900,6 +3900,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@8.1.0:
@@ -4886,13 +4887,16 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  prool@0.0.23:
-    resolution: {integrity: sha512-r1d0DIiVsp7aXqGiNGKmgrqJZa8GjMGEjsgjQO22DEClYYvK+HMPZTQ9diBqleGuwfiRk3lnsWRMbFTRmFbk9g==}
+  prool@0.2.4:
+    resolution: {integrity: sha512-KAGs6e++7MJNQ/vq8Xrk6akz0lRk6AmhuGzSHkluX3kwVj2XjNDDOYSINZwahRv3xfSD0rXYv3iA/2vXw7z47w==}
     engines: {node: '>=22'}
     peerDependencies:
       '@pimlico/alto': '*'
+      testcontainers: '>=11.10.0'
     peerDependenciesMeta:
       '@pimlico/alto':
+        optional: true
+      testcontainers:
         optional: true
 
   proxy-compare@2.5.1:
@@ -5392,6 +5396,7 @@ packages:
   tar@7.2.0:
     resolution: {integrity: sha512-hctwP0Nb4AB60bj8WQgRYaMOuJYRAPMGiQUAotms5igN8ppfQM+IvjQ5HcKu1MaZh2Wy2KWVTe563Yj8dfc14w==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -14051,7 +14056,7 @@ snapshots:
 
   process@0.11.10: {}
 
-  prool@0.0.23:
+  prool@0.2.4:
     dependencies:
       change-case: 5.4.4
       eventemitter3: 5.0.1


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `agw-client` package to use `publicClient` for estimating gas instead of the internal transport, along with several dependency updates and modifications to test setups.

### Detailed summary
- Replaced `client` with `publicClient` in `prepareTransaction.ts` for gas estimation.
- Updated `prool` dependency from version `0.0.23` to `0.2.4`.
- Added a global setup in `debug-global-setup.ts`.
- Modified `anvil.ts` to use `Instance.anvil.Parameters` and `Server.create`.
- Adjusted test files to reflect changes in `publicClient` usage.
- Enhanced error handling for unsupported methods in requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->