### PR TITLE
Archive AGW SDK docs and redirect to abstract-packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,87 +1,15 @@
 # Contribution Guidelines
 
-We’re excited that you’re interested in contributing to the Abstract Global Wallet SDK! ❤️ Contributions, whether they're bug reports, feature suggestions, documentation updates, or code enhancements, are highly appreciated.
+This repository is archived and is no longer accepting new issues, pull requests, or maintenance work.
 
-To make the contribution process smooth and efficient, please follow these guidelines.
+## Active Repository
 
-## How to Contribute
+For maintained package source, new issues, and future contributions, use [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
 
-### 1. Fork the Repository
+## Existing Consumers
 
-Fork the repository to your GitHub account to get started. This will create your own copy where you can make changes.
+If you landed here from an older link:
 
-1. Go to the main repository on GitHub.
-2. Click the "Fork" button in the top right corner.
-3. Once the repository is forked, clone it to your local machine. 
-
-### 2. Create a New Branch
-
-Before you start working on your changes, create a new branch for your work to keep the `main` branch clean:
-
-```bash
-git checkout -b your-branch-name
-```
-
-- Use a descriptive name for your branch (e.g., `feature/add-new-component` or `bugfix/fix-issue-123`).
-
-### 3. Make Your Changes
-
-Now that you have a branch set up, you can make changes to the codebase. When making changes:
-
-- Follow the existing code style and structure.
-- Write clear, concise commit messages that explain the "why" behind your changes.
-- Make sure your changes are well-tested. If applicable, add tests to validate the new functionality.
-
-### 4. Commit Your Changes
-
-Once you're happy with your changes and everything works as expected, commit them to your branch:
-
-```bash
-git add .
-git commit -m "description of your changes"
-```
-
-### 5. Push to Your Fork
-
-Push the changes to your fork on GitHub:
-
-```bash
-git push origin your-branch-name
-```
-
-### 6. Submit a Pull Request (PR)
-
-- **Title**: Use a concise and informative title for your pull request.
-- **Description**: Provide a detailed description of the changes made, why you made them, and any relevant details about the implementation.
-- **Link to Issue**: If your PR addresses an issue, please link to it (e.g., `Fixes #123`).
-
-Submit the pull request and wait for the review process to begin.
-
----
-
-## Reporting Bugs and Issues
-
-If you encounter a bug or want to suggest a feature:
-
-- Use the Github Issues page to report issues or request features.
-- Include as much detail as possible: steps to reproduce the issue, expected behavior, and screenshots if applicable.
-- If submitting a feature request, please explain the use case and benefits of the feature.
-
-### **How Do I Submit a Good Enhancement Suggestion?**
-
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/Abstract-Foundation/agw-sdk/issues).
-
-- Use a **clear and descriptive title** for the issue to identify the suggestion.
-- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
-- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://gitlab.gnome.org/Archive/byzanz) on Linux.
-- **Explain why this enhancement would be useful** to most agw-sdk users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
-
----
-
-## Coding Guidelines
-
-- Follow the existing structure and style of the codebase.
-- Ensure all functionality is thoroughly tested.
-- Write clear, self-documenting code and add comments when necessary.
-- Keep performance and security in mind when making changes.
+1. Use the package documentation in this repository only as historical reference.
+2. Use [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages) for current development.
+3. Use the [Abstract documentation site](https://docs.abs.xyz/how-abstract-works/abstract-global-wallet/overview) for product-level documentation.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # agw-sdk
 
-This repository is archived and no longer the active home for Abstract SDK packages.
-
-For maintained packages, source, and ongoing updates, use [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
+> [!IMPORTANT]
+> This repository is archived and no longer the active home for Abstract SDK packages.
+> For maintained packages, source, and ongoing updates, use [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
 
 ## Abstract Global Wallet (AGW)
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,36 @@
 # agw-sdk
-The Abstract Global Wallet SDK is a toolkit for developers to integrate the Abstract Global Wallet into their applications.
+
+This repository is archived and no longer the active home for Abstract SDK packages.
+
+For maintained packages, source, and ongoing updates, use [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
 
 ## Abstract Global Wallet (AGW)
 
-[Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview) is a cross-application [smart contract wallet](https://docs.abs.xyz/how-abstract-works/native-account-abstraction/smart-contract-wallets) that allows users to interact with any application built on Abstract. It is powered by Abstract's [native account abstraction](https://docs.abs.xyz/how-abstract-works/native-account-abstraction).
+[Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview) is a cross-application [smart contract wallet](https://docs.abs.xyz/how-abstract-works/native-account-abstraction/smart-contract-wallets) that allows users to interact with any application built on Abstract. It is powered by Abstract's [native account abstraction](https://docs.abs.xyz/how-abstract-works/native-account-abstraction).
 
-AGW allows users to sign up once using familiar login methods (such as email, social accounts, passkeys, and more), and then use this account to interact with *any* application on Abstract.
+AGW allows users to sign up once using familiar login methods (such as email, social accounts, passkeys, and more), and then use this account to interact with any application on Abstract.
 
 ![AGW SDK](https://pbs.twimg.com/media/GWF7DpqWkAAQJ2f?format=jpg&name=medium)
 
-
 ## Packages
 
-The SDK consists of two main packages:
+This repository previously published these packages:
 
 - [`@abstract-foundation/agw-client`](https://www.npmjs.com/package/@abstract-foundation/agw-client): The core client library for interacting with the Abstract Global Wallet.
 - [`@abstract-foundation/agw-react`](https://www.npmjs.com/package/@abstract-foundation/agw-react): React hooks and components for integrating the Abstract Global Wallet into React applications.
+- [`@abstract-foundation/agw-web`](https://www.npmjs.com/package/@abstract-foundation/agw-web): Web integrations for Abstract Global Wallet providers.
+- [`@abstract-foundation/web3-react-agw`](https://www.npmjs.com/package/@abstract-foundation/web3-react-agw): A `web3-react` connector for Abstract Global Wallet.
 
+For the current package sources, refer to [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
 
 ## Documentation
 
-For detailed documentation, please refer to the [Abstract Global Wallet Documentation](https://docs.abs.xyz/how-abstract-works/abstract-global-wallet/overview).
+For product documentation, refer to the [Abstract Global Wallet Documentation](https://docs.abs.xyz/how-abstract-works/abstract-global-wallet/overview).
+
+For actively maintained package source and repository-level updates, refer to [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
 
 ## Contributing
 
-We welcome contributions to the Abstract Global Wallet SDK! If you'd like to contribute, please follow these steps:
+This repository is archived and is not accepting new issues or pull requests.
 
-1. Fork the repository.
-2. Create a new branch for your feature or bugfix.
-3. Make your changes and commit with clear messages.
-4. Submit a pull request to the main repository.
+If you need to contribute to the actively maintained packages, start in [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).

--- a/packages/agw-client/README.md
+++ b/packages/agw-client/README.md
@@ -1,5 +1,7 @@
 # @abstract-foundation/agw-client
 
+This package README is kept for historical reference. The actively maintained package source now lives in [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
+
 The `@abstract-foundation/agw-client` package provides the core client library for interacting with the [Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview).
 
 ## Abstract Global Wallet (AGW)
@@ -142,3 +144,5 @@ import { Account } from 'viem/accounts';
 ## Documentation
 
 For detailed documentation, please refer to the [Abstract Global Wallet Documentation](https://docs.abs.xyz/how-abstract-works/abstract-global-wallet/overview).
+
+For maintained source and repository updates, refer to [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).

--- a/packages/agw-react/README.md
+++ b/packages/agw-react/README.md
@@ -1,5 +1,7 @@
 # @abstract-foundation/agw-react
 
+This package README is kept for historical reference. The actively maintained package source now lives in [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
+
 The `@abstract-foundation/agw-react` package provides React hooks and components to integrate the [Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview) into your React applications.
 
 ## Abstract Global Wallet (AGW)
@@ -145,3 +147,5 @@ export default function SponsoredContractWrite() {
 ## Documentation
 
 For detailed documentation, please refer to the [Abstract Global Wallet Documentation](https://docs.abs.xyz/how-abstract-works/abstract-global-wallet/overview).
+
+For maintained source and repository updates, refer to [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).

--- a/packages/agw-web/README.md
+++ b/packages/agw-web/README.md
@@ -1,0 +1,11 @@
+# @abstract-foundation/agw-web
+
+This package README is kept for historical reference. The actively maintained package source now lives in [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
+
+The `@abstract-foundation/agw-web` package provides web integrations for the [Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview).
+
+## Documentation
+
+For product documentation, refer to the [Abstract Global Wallet Documentation](https://docs.abs.xyz/how-abstract-works/abstract-global-wallet/overview).
+
+For maintained source and repository updates, refer to [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).

--- a/packages/web3-react-agw/README.md
+++ b/packages/web3-react-agw/README.md
@@ -1,5 +1,7 @@
 # @abstract-foundation/web3-react-agw
 
+This package README is kept for historical reference. The actively maintained package source now lives in [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).
+
 The `@abstract-foundation/web3-react-agw` package implements a [web3-react](https://github.com/Uniswap/web3-react) connector for [Abstract Global Wallet (AGW)](https://docs.abs.xyz/overview).
 
 ## Abstract Global Wallet (AGW)
@@ -79,3 +81,5 @@ Creates an `AbstractGlobalWallet` connector, extending the web3-react `Connector
 ## Documentation
 
 For detailed documentation, please refer to the [Abstract Global Wallet Documentation](https://docs.abs.xyz/how-abstract-works/abstract-global-wallet/overview).
+
+For maintained source and repository updates, refer to [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages).


### PR DESCRIPTION
## Summary
- Marked the repository and package READMEs as historical/archived.
- Redirected contributors and consumers to `Abstract-Foundation/abstract-packages` for active development and maintained sources.
- Added the missing `@abstract-foundation/agw-web` package README and updated package-level documentation links.
- Kept product documentation links pointing to the Abstract docs site for end-user guidance.

## Testing
- Not run (documentation-only changes).
- Reviewed the updated README content for consistent archive messaging and link targets.
- Confirmed the new `packages/agw-web/README.md` file is present and matches the redirect pattern used elsewhere.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the README files across multiple packages to clarify that they are archived and no longer the active home for the Abstract Global Wallet SDK packages. It directs users to the new repository for actively maintained packages.

### Detailed summary
- Added historical reference notes in `README.md` files for `@abstract-foundation/agw-web`, `@abstract-foundation/agw-client`, `@abstract-foundation/agw-react`, and `@abstract-foundation/web3-react-agw`.
- Updated main `README.md` to indicate archiving and redirect to [`Abstract-Foundation/abstract-packages`](https://github.com/Abstract-Foundation/abstract-packages) for active development.
- Removed contribution instructions and emphasized the archived status of the repository.
- Clarified the purpose of the `Abstract Global Wallet (AGW)` in the main `README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->